### PR TITLE
Fixes: one way data flow

### DIFF
--- a/command.go
+++ b/command.go
@@ -104,3 +104,14 @@ func readNextWord(text string) (word string, next string) {
 	}
 	return
 }
+
+func sendCommand(cmdChan chan<- Command, cmd Command) bool {
+	defer func() { recover() }() // catch panics if the channel was already closed
+	cmdChan <- cmd
+	return true
+}
+
+func closeCommand(cmdChan chan<- Command) {
+	defer func() { recover() }() // make the close operation idempotent
+	close(cmdChan)
+}

--- a/consumer.go
+++ b/consumer.go
@@ -265,15 +265,9 @@ func (c *Consumer) writeConn(conn *Conn, cmdChan chan Command) {
 	defer conn.Close()
 	defer closeCommand(cmdChan)
 
-	for {
-		select {
-		case cmd := <-cmdChan:
-			if err := c.writeConnCommand(conn, cmd); err != nil {
-				log.Print(err)
-				return
-			}
-
-		case <-c.done:
+	for cmd := range cmdChan {
+		if err := c.writeConnCommand(conn, cmd); err != nil {
+			log.Print(err)
 			return
 		}
 	}

--- a/frame.go
+++ b/frame.go
@@ -155,8 +155,3 @@ func writeFrameHeader(w *bufio.Writer, ftype FrameType, size int) (err error) {
 
 	return
 }
-
-func closeFrameChan(c chan<- Frame) {
-	defer func() { recover() }() // make the close operation idempotent
-	close(c)
-}

--- a/frame.go
+++ b/frame.go
@@ -155,3 +155,8 @@ func writeFrameHeader(w *bufio.Writer, ftype FrameType, size int) (err error) {
 
 	return
 }
+
+func closeFrameChan(c chan<- Frame) {
+	defer func() { recover() }() // make the close operation idempotent
+	close(c)
+}

--- a/producer.go
+++ b/producer.go
@@ -25,7 +25,6 @@ type ProducerConfig struct {
 // nodes to send messages.
 type Producer struct {
 	// Communication channels of the producer.
-	cmds chan Command
 	reqs chan ProducerRequest
 	done chan struct{}
 	once sync.Once
@@ -87,7 +86,6 @@ func StartProducer(config ProducerConfig) (p *Producer, err error) {
 	}
 
 	p = &Producer{
-		cmds:            make(chan Command, config.MaxConcurrency),
 		reqs:            make(chan ProducerRequest, config.MaxConcurrency),
 		done:            make(chan struct{}),
 		address:         config.Address,

--- a/producer.go
+++ b/producer.go
@@ -216,7 +216,6 @@ func (p *Producer) run() {
 				}
 
 				retry = 0
-				pending = make([]ProducerRequest, 0)
 				resChan = make(chan Frame, 16)
 				go p.flush(conn, resChan)
 			}


### PR DESCRIPTION
@f2prateek 
@yields 
@dominicbarnes 

Couple of changes to make the code more robust and fix a deadlock in the producer code.

**Consumer**
Cleanup code to avoid panics or deadlocks that may happen on corner cases.

**Producer**
Fix the deadlock that occurred when the read loop was publishing a ping to the write loop while the write loop was publishing a pending request to the read loop. Now all data flows are unidirectional:
- program => request chan => write loop
- read loop => response chan => write loop
- connection losses or timeouts abort all pending requests

Please take a look and let me know if you see anything that should be changed.
