### PR TITLE
Consul

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,11 @@ version: '2'
 # Use this docker-compose file to setup the test environment before running the
 # tests.
 services:
+  consul:
+    image: consul:latest
+    command: agent -server -dev -log-level debug
+    network_mode: host
+
   nsqlookupd-1:
     image: nsqio/nsq
     command: >

--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -1,0 +1,306 @@
+package nsqlookup
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultConsulAddress  = "localhost:8500"
+	DefaultRequestTimeout = 10 * time.Second
+)
+
+type ConsulConfig struct {
+	Address          string
+	NodeTimeout      time.Duration
+	TombstoneTimeout time.Duration
+	RequestTimeout   time.Duration
+	Transport        http.RoundTripper
+}
+
+type ConsulEngine struct {
+	client      http.Client
+	address     string
+	nodeTimeout time.Duration
+	tombTimeout time.Duration
+
+	once  sync.Once
+	mutex sync.RWMutex
+	nodes map[string]*consulNode
+}
+
+type consulNode struct {
+	mutex   sync.Mutex
+	sid     string
+	err     error
+	expTime time.Time
+}
+
+func NewConsulEngine(config ConsulConfig) *ConsulEngine {
+	if len(config.Address) == 0 {
+		config.Address = DefaultConsulAddress
+	}
+
+	if config.NodeTimeout == 0 {
+		config.NodeTimeout = DefaultLocalEngineNodeTimeout
+	}
+
+	if config.TombstoneTimeout == 0 {
+		config.TombstoneTimeout = DefaultLocalEngineTombstoneTimeout
+	}
+
+	if config.RequestTimeout == 0 {
+		config.RequestTimeout = DefaultRequestTimeout
+	}
+
+	if !strings.Contains(config.Address, "://") {
+		config.Address = "http://" + config.Address
+	}
+
+	return &ConsulEngine{
+		client: http.Client{
+			Transport: config.Transport,
+			Timeout:   config.RequestTimeout,
+		},
+		address:     config.Address,
+		nodeTimeout: config.NodeTimeout,
+		tombTimeout: config.TombstoneTimeout,
+		nodes:       make(map[string]*consulNode),
+	}
+}
+
+func (e *ConsulEngine) Close() (err error) {
+	e.once.Do(func() {
+		e.mutex.Lock()
+		list := make([]string, 0, len(e.nodes))
+
+		for _, node := range e.nodes {
+			node.mutex.Lock()
+			if sid := node.sid; len(sid) != 0 {
+				list = append(list, sid)
+			}
+			node.mutex.Unlock()
+		}
+
+		e.nodes = nil
+		e.mutex.Unlock()
+
+		g := &sync.WaitGroup{}
+
+		for _, sid := range list {
+			g.Add(1)
+			go func(sid string) {
+				e.destroySession(sid)
+				g.Done()
+			}(sid)
+		}
+
+		g.Wait()
+	})
+	return
+}
+
+func (e *ConsulEngine) RegisterNode(node NodeInfo) (err error) {
+
+	return
+}
+
+func (e *ConsulEngine) UnregisterNode(node NodeInfo) (err error) {
+
+	return
+}
+
+func (e *ConsulEngine) PingNode(node NodeInfo) (err error) {
+
+	return
+}
+
+func (e *ConsulEngine) TombstoneTopic(node NodeInfo, topic string) (err error) {
+
+	return
+}
+
+func (e *ConsulEngine) RegisterTopic(node NodeInfo, topic string) (err error) {
+
+	return
+}
+
+func (e *ConsulEngine) UnregisterTopic(node NodeInfo, topic string) (err error) {
+
+	return
+}
+
+func (e *ConsulEngine) RegisterChannel(node NodeInfo, topic string, channel string) (err error) {
+
+	return
+}
+
+func (e *ConsulEngine) UnregisterChannel(node NodeInfo, topic string, channel string) (err error) {
+
+	return
+}
+
+func (e *ConsulEngine) LookupNodes() (nodes []NodeInfo, err error) {
+
+	return
+}
+
+func (e *ConsulEngine) LookupProducers(topic string) (producers []NodeInfo, err error) {
+
+	return
+}
+
+func (e *ConsulEngine) LookupTopics() (topics []string, err error) {
+
+	return
+}
+
+func (e *ConsulEngine) LookupChannels(topic string) (channels []string, err error) {
+
+	return
+}
+
+func (e *ConsulEngine) LookupInfo() (info EngineInfo, err error) {
+	info.Type = "consul"
+	info.Version = "0.3.8"
+	return
+}
+
+func (e *ConsulEngine) CheckHealth() (err error) {
+
+	return
+}
+
+func (e *ConsulEngine) session(node string) (sid string, err error) {
+	e.mutex.RLock()
+
+	if e.nodes == nil {
+		err = io.ErrClosedPipe
+	} else if n := e.nodes[node]; n != nil {
+		sid = n.sid
+		err = n.err
+	}
+
+	e.mutex.RUnlock()
+
+	if len(sid) == 0 && err == nil {
+		n := &consulNode{}
+		n.mutex.Lock()
+		e.mutex.Lock()
+
+		if n := e.nodes[node]; n != nil {
+			sid = n.sid
+			err = n.err
+			e.mutex.Unlock()
+			return
+		}
+
+		e.nodes[node] = n
+		e.mutex.Unlock()
+
+		if sid, err = e.createSession(); err != nil {
+			n.err = err
+		} else {
+			n.sid = sid
+		}
+
+		n.mutex.Unlock()
+
+		if err != nil {
+			e.mutex.Lock()
+			delete(e.nodes, node)
+			e.mutex.Unlock()
+		}
+	}
+
+	return
+}
+
+func (e *ConsulEngine) createSession() (sid string, err error) {
+	const minTTL = time.Second * 10
+	const maxTTL = time.Second * 86400
+
+	var session struct{ ID string }
+	var ttl time.Duration
+
+	if ttl = e.nodeTimeout; ttl < minTTL {
+		ttl = minTTL
+	} else if ttl > maxTTL {
+		ttl = maxTTL
+	}
+
+	if err = e.put("/v1/session/create", struct {
+		LockDelay string
+		Name      string
+		Behavior  string
+		TTL       string
+	}{
+		LockDelay: "15s",
+		Name:      "nsqlookupd consul engine",
+		Behavior:  "delete",
+		TTL:       fmt.Sprint("%ds", int(ttl.Seconds())),
+	}, &session); err != nil {
+		return
+	}
+
+	sid = session.ID
+	return
+}
+
+func (e *ConsulEngine) destroySession(sid string) error {
+	return e.delete("/v1/session/destroy/" + sid)
+}
+
+func (e *ConsulEngine) renewSession(sid string) error {
+	return e.put("/v1/session/renew/"+sid, nil, nil)
+}
+
+func (e *ConsulEngine) get(path string, recv interface{}) error {
+	return e.do("GET", path, nil, recv)
+}
+
+func (e *ConsulEngine) put(path string, send interface{}, recv interface{}) error {
+	return e.do("PUT", path, send, recv)
+}
+
+func (e *ConsulEngine) delete(path string) error {
+	return e.do("DELETE", path, nil, nil)
+}
+
+func (e *ConsulEngine) do(method string, path string, send interface{}, recv interface{}) (err error) {
+	var req *http.Request
+	var res *http.Response
+	var b []byte
+
+	if send != nil {
+		if b, err = json.Marshal(send); err != nil {
+			return
+		}
+	}
+
+	if req, err = http.NewRequest(method, path, bytes.NewReader(b)); err != nil {
+		return
+	}
+
+	if res, err = e.client.Do(req); err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	if recv != nil {
+		if err = json.NewDecoder(res.Body).Decode(recv); err != nil {
+			return
+		}
+	} else {
+		io.Copy(ioutil.Discard, res.Body)
+	}
+
+	return
+}

--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -591,19 +591,19 @@ func (e *ConsulEngine) key(key string) string {
 	return path.Join("/v1/kv", e.namespace, key)
 }
 
-func (e *ConsulEngine) get(path string, recv interface{}) error {
-	return e.do("GET", path, nil, recv)
+func (e *ConsulEngine) get(url string, recv interface{}) error {
+	return e.do("GET", url, nil, recv)
 }
 
-func (e *ConsulEngine) put(path string, send interface{}, recv interface{}) error {
-	return e.do("PUT", path, send, recv)
+func (e *ConsulEngine) put(url string, send interface{}, recv interface{}) error {
+	return e.do("PUT", url, send, recv)
 }
 
-func (e *ConsulEngine) delete(path string) error {
-	return e.do("DELETE", path, nil, nil)
+func (e *ConsulEngine) delete(url string) error {
+	return e.do("DELETE", url, nil, nil)
 }
 
-func (e *ConsulEngine) do(method string, path string, send interface{}, recv interface{}) (err error) {
+func (e *ConsulEngine) do(method string, url string, send interface{}, recv interface{}) (err error) {
 	var req *http.Request
 	var res *http.Response
 	var b []byte
@@ -622,7 +622,9 @@ func (e *ConsulEngine) do(method string, path string, send interface{}, recv int
 		}
 	}
 
-	if req, err = http.NewRequest(method, e.address+path, bytes.NewReader(b)); err != nil {
+	url = e.address + url
+
+	if req, err = http.NewRequest(method, url, bytes.NewReader(b)); err != nil {
 		return
 	}
 
@@ -635,7 +637,7 @@ func (e *ConsulEngine) do(method string, path string, send interface{}, recv int
 		io.Copy(ioutil.Discard, res.Body)
 		err = consulError{
 			method: method,
-			path:   path,
+			url:    url,
 			status: res.StatusCode,
 			reason: res.Status,
 		}
@@ -689,13 +691,13 @@ func consulErrorNotFound(err error) bool {
 // 200 in responses from the consul agent.
 type consulError struct {
 	method string
-	path   string
+	url    string
 	status int
 	reason string
 }
 
 func (e consulError) Error() string {
-	return fmt.Sprintf("%s %s: %s", e.method, e.path, e.reason)
+	return fmt.Sprintf("%s %s: %s", e.method, e.url, e.reason)
 }
 
 // This structure is used for internal representation of the nodes registered

--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -16,18 +16,39 @@ import (
 )
 
 const (
-	DefaultConsulAddress  = "localhost:8500"
-	DefaultRequestTimeout = 10 * time.Second
+	// DefaultConsulAddress is the default address at which a consul agent is
+	// expected to be available for consul engines.
+	DefaultConsulAddress = "localhost:8500"
+
+	// DefaultConsulRequestTimeout is the maximum amount of time that requests
+	// to a consul agent are allowed to take.
+	DefaultConsulRequestTimeout = 1 * time.Second
 )
 
+// The ConsulConfig structure is used to configure consul engines.
 type ConsulConfig struct {
-	Address          string
-	NodeTimeout      time.Duration
+	// The address at which the consul agent is exposing its HTTP API.
+	Address string
+
+	// NodeTImeout is the maximum amount of time a node is allowed to be idle
+	// before it gets evicted.
+	NodeTimeout time.Duration
+
+	// TomstoneTimeout is the amount of time after which a tombstone set on a
+	// topic is evisted.
 	TombstoneTimeout time.Duration
-	RequestTimeout   time.Duration
-	Transport        http.RoundTripper
+
+	// RequestTimeout is the maximum amount of time allowed for requests to
+	// consul agents to respond.
+	RequestTimeout time.Duration
+
+	// Transport used by the engine's HTTP client, the default transport is used
+	// if none is provided.
+	Transport http.RoundTripper
 }
 
+// ConsulEngine are objects that provide the implementation of a nsqlookup
+// engine backed by a consul infrastructure.
 type ConsulEngine struct {
 	client      http.Client
 	address     string
@@ -46,6 +67,7 @@ type consulNode struct {
 	expTime time.Time
 }
 
+// NewConsulEngine creates and return a new engine configured with config.
 func NewConsulEngine(config ConsulConfig) *ConsulEngine {
 	if len(config.Address) == 0 {
 		config.Address = DefaultConsulAddress
@@ -60,7 +82,7 @@ func NewConsulEngine(config ConsulConfig) *ConsulEngine {
 	}
 
 	if config.RequestTimeout == 0 {
-		config.RequestTimeout = DefaultRequestTimeout
+		config.RequestTimeout = DefaultConsulRequestTimeout
 	}
 
 	if !strings.Contains(config.Address, "://") {

--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -22,7 +22,7 @@ const (
 
 	// DefaultConsulRequestTimeout is the maximum amount of time that requests
 	// to a consul agent are allowed to take.
-	DefaultConsulRequestTimeout = 1 * time.Second
+	DefaultConsulRequestTimeout = 10 * time.Second
 )
 
 // The ConsulConfig structure is used to configure consul engines.

--- a/nsqlookup/engine_test.go
+++ b/nsqlookup/engine_test.go
@@ -26,6 +26,15 @@ func testEngine(t *testing.T, do func(*testing.T, Engine)) {
 				})
 			},
 		},
+		{
+			Type: "consul",
+			New: func() Engine {
+				return NewConsulEngine(ConsulConfig{
+					NodeTimeout:      nodeTimeout,
+					TombstoneTimeout: tombTimeout,
+				})
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/nsqlookup/engine_test.go
+++ b/nsqlookup/engine_test.go
@@ -64,9 +64,7 @@ func testEngine(t *testing.T, do func(*testing.T, Engine)) {
 
 func TestEngineClose(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
-		if err := e.Close(); err != nil {
-			t.Error(err)
-		}
+		checkNilError(t, e.Close())
 	})
 }
 
@@ -80,17 +78,13 @@ func TestEngineRegisterNode(t *testing.T) {
 
 		for _, node := range nodes1 {
 			t.Run(node.Hostname, func(t *testing.T) {
-				if err := e.RegisterNode(node); err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, e.RegisterNode(node))
 			})
 		}
 
 		t.Run("lookup-nodes", func(t *testing.T) {
 			nodes2, err := e.LookupNodes()
-			if err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, err)
 			checkEqualNodes(t, nodes1, nodes2)
 		})
 	})
@@ -105,23 +99,33 @@ func TestEngineUnregisterNode(t *testing.T) {
 		}
 
 		for _, node := range nodes1 {
-			if err := e.RegisterNode(node); err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, e.RegisterNode(node))
+		}
+
+		for _, channel := range [...]string{"1", "2", "3"} {
+			checkNilError(t, e.RegisterChannel(nodes1[0], "A", channel))
 		}
 
 		t.Run("unregister", func(t *testing.T) {
-			if err := e.UnregisterNode(nodes1[0]); err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, e.UnregisterNode(nodes1[0]))
 		})
 
 		t.Run("lookup-nodes", func(t *testing.T) {
 			nodes2, err := e.LookupNodes()
-			if err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, err)
 			checkEqualNodes(t, nodes1[1:], nodes2)
+		})
+
+		t.Run("lookup-topics", func(t *testing.T) {
+			topics, err := e.LookupTopics()
+			checkNilError(t, err)
+			checkEqualTopics(t, nil, topics)
+		})
+
+		t.Run("lookup-channels", func(t *testing.T) {
+			channels, err := e.LookupChannels("A")
+			checkNilError(t, err)
+			checkEqualChannels(t, nil, channels)
 		})
 	})
 }
@@ -135,16 +139,12 @@ func TestEnginePingNode(t *testing.T) {
 		}
 
 		for _, node := range nodes1 {
-			if err := e.RegisterNode(node); err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, e.RegisterNode(node))
 		}
 
 		for _, node := range nodes1 {
 			t.Run(node.Hostname, func(t *testing.T) {
-				if err := e.PingNode(node); err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, e.PingNode(node))
 			})
 		}
 	})
@@ -165,25 +165,19 @@ func TestEngineTombstoneTopic(t *testing.T) {
 		}
 
 		for _, node := range nodes1 {
-			if err := e.RegisterNode(node); err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, e.RegisterNode(node))
 		}
 
 		for i, node := range nodes1 {
 			for _, topic := range topics1[i] {
-				if err := e.RegisterTopic(node, topic); err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, e.RegisterTopic(node, topic))
 			}
 		}
 
 		t.Run("tombstone", func(t *testing.T) {
 			for _, node := range nodes1 {
 				t.Run(node.Hostname, func(t *testing.T) {
-					if err := e.TombstoneTopic(node, "A"); err != nil {
-						t.Error(err)
-					}
+					checkNilError(t, e.TombstoneTopic(node, "A"))
 				})
 			}
 		})
@@ -198,18 +192,14 @@ func TestEngineTombstoneTopic(t *testing.T) {
 		} {
 			t.Run(test.topic, func(t *testing.T) {
 				nodes, err := e.LookupProducers(test.topic)
-				if err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, err)
 				checkEqualNodes(t, test.nodes, nodes)
 			})
 		}
 
 		t.Run("lookup-topics", func(t *testing.T) {
 			topics2, err := e.LookupTopics()
-			if err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, err)
 			checkEqualTopics(t, []string{"A", "B", "C"}, topics2)
 		})
 
@@ -226,18 +216,14 @@ func TestEngineTombstoneTopic(t *testing.T) {
 		} {
 			t.Run(test.topic, func(t *testing.T) {
 				nodes, err := e.LookupProducers(test.topic)
-				if err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, err)
 				checkEqualNodes(t, test.nodes, nodes)
 			})
 		}
 
 		t.Run("lookup-topics", func(t *testing.T) {
 			topics2, err := e.LookupTopics()
-			if err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, err)
 			checkEqualTopics(t, []string{"A", "B", "C"}, topics2)
 		})
 	})
@@ -258,18 +244,14 @@ func TestEngineRegisterTopic(t *testing.T) {
 		}
 
 		for _, node := range nodes1 {
-			if err := e.RegisterNode(node); err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, e.RegisterNode(node))
 		}
 
 		for i, node := range nodes1 {
 			t.Run(node.Hostname, func(t *testing.T) {
 				for _, topic := range topics1[i] {
 					t.Run(topic, func(t *testing.T) {
-						if err := e.RegisterTopic(node, topic); err != nil {
-							t.Error(err)
-						}
+						checkNilError(t, e.RegisterTopic(node, topic))
 					})
 				}
 			})
@@ -286,18 +268,14 @@ func TestEngineRegisterTopic(t *testing.T) {
 		} {
 			t.Run(test.topic, func(t *testing.T) {
 				nodes, err := e.LookupProducers(test.topic)
-				if err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, err)
 				checkEqualNodes(t, test.nodes, nodes)
 			})
 		}
 
 		t.Run("lookup-topics", func(t *testing.T) {
 			topics2, err := e.LookupTopics()
-			if err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, err)
 			checkEqualTopics(t, []string{"A", "B", "C"}, topics2)
 		})
 	})
@@ -318,24 +296,18 @@ func TestEngineUnregisterTopic(t *testing.T) {
 		}
 
 		for _, node := range nodes1 {
-			if err := e.RegisterNode(node); err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, e.RegisterNode(node))
 		}
 
 		for i, node := range nodes1 {
 			for _, topic := range topics1[i] {
-				if err := e.RegisterTopic(node, topic); err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, e.RegisterTopic(node, topic))
 			}
 		}
 
 		for _, node := range nodes1 {
 			t.Run(node.Hostname, func(t *testing.T) {
-				if err := e.UnregisterTopic(node, "A"); err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, e.UnregisterTopic(node, "A"))
 			})
 		}
 
@@ -350,19 +322,21 @@ func TestEngineUnregisterTopic(t *testing.T) {
 		} {
 			t.Run(test.topic, func(t *testing.T) {
 				nodes, err := e.LookupProducers(test.topic)
-				if err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, err)
 				checkEqualNodes(t, test.nodes, nodes)
 			})
 		}
 
 		t.Run("lookup-topics", func(t *testing.T) {
 			topics2, err := e.LookupTopics()
-			if err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, err)
 			checkEqualTopics(t, []string{"B", "C"}, topics2)
+		})
+
+		t.Run("lookup-channels", func(t *testing.T) {
+			channels, err := e.LookupChannels("A")
+			checkNilError(t, err)
+			checkEqualChannels(t, nil, channels)
 		})
 	})
 }
@@ -382,18 +356,14 @@ func TestEngineRegisterChannel(t *testing.T) {
 		}
 
 		for _, node := range nodes1 {
-			if err := e.RegisterNode(node); err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, e.RegisterNode(node))
 		}
 
 		for i, node := range nodes1 {
 			t.Run(node.Hostname, func(t *testing.T) {
 				for _, channel := range channels1[i] {
 					t.Run(channel, func(t *testing.T) {
-						if err := e.RegisterChannel(node, "A", channel); err != nil {
-							t.Error(err)
-						}
+						checkNilError(t, e.RegisterChannel(node, "A", channel))
 					})
 				}
 			})
@@ -401,9 +371,7 @@ func TestEngineRegisterChannel(t *testing.T) {
 
 		t.Run("lookup-channels", func(t *testing.T) {
 			channels2, err := e.LookupChannels("A")
-			if err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, err)
 			checkEqualChannels(t, []string{"1", "2", "3"}, channels2)
 		})
 	})
@@ -424,32 +392,24 @@ func TestEngineUnregisterChannel(t *testing.T) {
 		}
 
 		for _, node := range nodes1 {
-			if err := e.RegisterNode(node); err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, e.RegisterNode(node))
 		}
 
 		for i, node := range nodes1 {
 			for _, channel := range channels1[i] {
-				if err := e.RegisterChannel(node, "A", channel); err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, e.RegisterChannel(node, "A", channel))
 			}
 		}
 
 		for _, node := range nodes1 {
 			t.Run(node.Hostname, func(t *testing.T) {
-				if err := e.UnregisterChannel(node, "A", "1"); err != nil {
-					t.Error(err)
-				}
+				checkNilError(t, e.UnregisterChannel(node, "A", "1"))
 			})
 		}
 
 		t.Run("lookup-channels", func(t *testing.T) {
 			channels2, err := e.LookupChannels("A")
-			if err != nil {
-				t.Error(err)
-			}
+			checkNilError(t, err)
 			checkEqualChannels(t, []string{"2", "3"}, channels2)
 		})
 	})
@@ -457,9 +417,7 @@ func TestEngineUnregisterChannel(t *testing.T) {
 
 func TestEngineCheckHealth(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
-		if err := e.CheckHealth(); err != nil {
-			t.Error(err)
-		}
+		checkNilError(t, e.CheckHealth())
 	})
 }
 
@@ -512,5 +470,11 @@ func checkEqualChannels(t *testing.T, c1 []string, c2 []string) {
 		t.Error("bad channels")
 		t.Log("<<<", c1)
 		t.Log(">>>", c2)
+	}
+}
+
+func checkNilError(t *testing.T, err error) {
+	if err != nil {
+		t.Error(err)
 	}
 }

--- a/nsqlookup/engine_test.go
+++ b/nsqlookup/engine_test.go
@@ -204,7 +204,7 @@ func TestEngineTombstoneTopic(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			checkEqualTopics(t, []string{"B", "C"}, topics2)
+			checkEqualTopics(t, []string{"A", "B", "C"}, topics2)
 		})
 
 		// Sleep for a little while to give time to the tombstone to expire.

--- a/nsqlookup/engine_test.go
+++ b/nsqlookup/engine_test.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	nodeTimeout = 1 * time.Minute
-	tombTimeout = 100 * time.Millisecond
+	tombTimeout = 50 * time.Millisecond
 )
 
 func init() {

--- a/nsqlookup/engine_test.go
+++ b/nsqlookup/engine_test.go
@@ -3,6 +3,7 @@ package nsqlookup
 import (
 	"fmt"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -39,7 +40,7 @@ func testEngine(t *testing.T, do func(*testing.T, Engine)) {
 
 	for _, test := range tests {
 		t.Run(test.Type, func(t *testing.T) {
-			t.Parallel()
+			//			t.Parallel()
 
 			e := test.New()
 			defer e.Close()
@@ -66,9 +67,9 @@ func TestEngineClose(t *testing.T) {
 func TestEngineRegisterNode(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
 		nodes1 := []NodeInfo{
-			makeNodeInfo(1),
-			makeNodeInfo(2),
-			makeNodeInfo(3),
+			makeNodeInfo(),
+			makeNodeInfo(),
+			makeNodeInfo(),
 		}
 
 		for _, node := range nodes1 {
@@ -92,9 +93,9 @@ func TestEngineRegisterNode(t *testing.T) {
 func TestEngineUnregisterNode(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
 		nodes1 := []NodeInfo{
-			makeNodeInfo(1),
-			makeNodeInfo(2),
-			makeNodeInfo(3),
+			makeNodeInfo(),
+			makeNodeInfo(),
+			makeNodeInfo(),
 		}
 
 		for _, node := range nodes1 {
@@ -122,9 +123,9 @@ func TestEngineUnregisterNode(t *testing.T) {
 func TestEnginePingNode(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
 		nodes1 := []NodeInfo{
-			makeNodeInfo(1),
-			makeNodeInfo(2),
-			makeNodeInfo(3),
+			makeNodeInfo(),
+			makeNodeInfo(),
+			makeNodeInfo(),
 		}
 
 		for _, node := range nodes1 {
@@ -146,9 +147,9 @@ func TestEnginePingNode(t *testing.T) {
 func TestEngineTombstoneTopic(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
 		nodes1 := []NodeInfo{
-			makeNodeInfo(1),
-			makeNodeInfo(2),
-			makeNodeInfo(3),
+			makeNodeInfo(),
+			makeNodeInfo(),
+			makeNodeInfo(),
 		}
 
 		topics1 := [][]string{
@@ -239,9 +240,9 @@ func TestEngineTombstoneTopic(t *testing.T) {
 func TestEngineRegisterTopic(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
 		nodes1 := []NodeInfo{
-			makeNodeInfo(1),
-			makeNodeInfo(2),
-			makeNodeInfo(3),
+			makeNodeInfo(),
+			makeNodeInfo(),
+			makeNodeInfo(),
 		}
 
 		topics1 := [][]string{
@@ -299,9 +300,9 @@ func TestEngineRegisterTopic(t *testing.T) {
 func TestEngineUnregisterTopic(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
 		nodes1 := []NodeInfo{
-			makeNodeInfo(1),
-			makeNodeInfo(2),
-			makeNodeInfo(3),
+			makeNodeInfo(),
+			makeNodeInfo(),
+			makeNodeInfo(),
 		}
 
 		topics1 := [][]string{
@@ -363,9 +364,9 @@ func TestEngineUnregisterTopic(t *testing.T) {
 func TestEngineRegisterChannel(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
 		nodes1 := []NodeInfo{
-			makeNodeInfo(1),
-			makeNodeInfo(2),
-			makeNodeInfo(3),
+			makeNodeInfo(),
+			makeNodeInfo(),
+			makeNodeInfo(),
 		}
 
 		channels1 := [][]string{
@@ -405,9 +406,9 @@ func TestEngineRegisterChannel(t *testing.T) {
 func TestEngineUnregisterChannel(t *testing.T) {
 	testEngine(t, func(t *testing.T, e Engine) {
 		nodes1 := []NodeInfo{
-			makeNodeInfo(1),
-			makeNodeInfo(2),
-			makeNodeInfo(3),
+			makeNodeInfo(),
+			makeNodeInfo(),
+			makeNodeInfo(),
 		}
 
 		channels1 := [][]string{
@@ -456,13 +457,21 @@ func TestEngineCheckHealth(t *testing.T) {
 	})
 }
 
-func makeNodeInfo(i int) NodeInfo {
+var (
+	hosts uint32 = 0
+	ports uint32 = 1024
+)
+
+func makeNodeInfo() NodeInfo {
+	h1 := atomic.AddUint32(&hosts, 1)
+	p1 := atomic.AddUint32(&ports, 1)
+	p2 := atomic.AddUint32(&ports, 1)
 	return NodeInfo{
-		RemoteAddress:    fmt.Sprintf("10.0.0.%d:35000", i),
-		BroadcastAddress: fmt.Sprintf("10.0.0.%d", i),
-		Hostname:         fmt.Sprintf("host-%d", i),
-		TcpPort:          4150,
-		HttpPort:         4151,
+		RemoteAddress:    "10.0.0.1:35000",
+		BroadcastAddress: "10.0.0.1",
+		Hostname:         fmt.Sprintf("host-%d", h1),
+		TcpPort:          int(p1),
+		HttpPort:         int(p2),
 		Version:          "0.3.8",
 	}
 }

--- a/nsqlookup/error.go
+++ b/nsqlookup/error.go
@@ -3,6 +3,7 @@ package nsqlookup
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 )
 
@@ -83,4 +84,11 @@ func isTemporary(err error) bool {
 		Temporary() bool
 	})
 	return ok && e.Temporary()
+}
+
+func appendError(err error, e error) error {
+	if err == nil {
+		return e
+	}
+	return errors.New(err.Error() + "; " + e.Error())
 }

--- a/nsqlookup/local.go
+++ b/nsqlookup/local.go
@@ -332,9 +332,7 @@ func (n *localNode) lookupTopics(topics map[string]bool) {
 	n.mutex.RLock()
 
 	for topic := range n.topics {
-		if _, skip := n.tombs[topic]; !skip {
-			topics[topic] = true
-		}
+		topics[topic] = true
 	}
 
 	n.mutex.RUnlock()


### PR DESCRIPTION
@yields 
@calvinfo 
@rbranson 
@thehydroimpulse 

Hey guys, I've spent a bit of time working on the implementation of a nsqlookup replacement based on consul, here's the implementation.

The way it works:
- when a node register a new consul session is created
- topics and channels registered by the nsqd nodes are stored in consul's key/value store attached to the session
- discovering nodes that host topics is a simple request to the key/value store
- when a node unregisters its session is expired, which automatically expires all keys associated with it in the store, which means they won't be advertised as hosting their topics anymore.

Please take a look and let me know what you think about this. As a reminder the idea here is to replace nsqlookup with something that takes advantage of consul's shared key/value store so we don't have to reference the list of IP address of existing nsqlookupd services.