### PR TITLE
refactor to support passing a cancellation context

### DIFF
--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -2,6 +2,7 @@ package nsqlookup
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,10 +24,6 @@ const (
 	// DefaultConsulNamespace is the key namespace used by default by the consul
 	// engine.
 	DefaultConsulNamespace = "nsqlookup"
-
-	// DefaultConsulRequestTimeout is the maximum amount of time that requests
-	// to a consul agent are allowed to take.
-	DefaultConsulRequestTimeout = 10 * time.Second
 )
 
 // The ConsulConfig structure is used to configure consul engines.
@@ -45,10 +42,6 @@ type ConsulConfig struct {
 	// TomstoneTimeout is the amount of time after which a tombstone set on a
 	// topic is evisted.
 	TombstoneTimeout time.Duration
-
-	// RequestTimeout is the maximum amount of time allowed for requests to
-	// consul agents to respond.
-	RequestTimeout time.Duration
 
 	// Transport used by the engine's HTTP client, the default transport is used
 	// if none is provided.
@@ -87,10 +80,6 @@ func NewConsulEngine(config ConsulConfig) *ConsulEngine {
 		config.TombstoneTimeout = DefaultLocalEngineTombstoneTimeout
 	}
 
-	if config.RequestTimeout == 0 {
-		config.RequestTimeout = DefaultConsulRequestTimeout
-	}
-
 	if !strings.Contains(config.Address, "://") {
 		config.Address = "http://" + config.Address
 	}
@@ -98,7 +87,6 @@ func NewConsulEngine(config ConsulConfig) *ConsulEngine {
 	return &ConsulEngine{
 		client: http.Client{
 			Transport: config.Transport,
-			Timeout:   config.RequestTimeout,
 		},
 		address:     config.Address,
 		namespace:   config.Namespace,
@@ -130,17 +118,17 @@ func (e *ConsulEngine) Close() (err error) {
 			join.Add(1)
 			go func(sid string) {
 				defer join.Done()
-				e.destroySession(sid)
+				e.destroySession(sid, nil)
 			}(sid)
 		}
 
-		e.unsetKey(e.key("")) // remove the namespace
+		e.unsetKey(e.key(""), nil) // remove the namespace
 		join.Wait()
 	})
 	return
 }
 
-func (e *ConsulEngine) RegisterNode(node NodeInfo) (err error) {
+func (e *ConsulEngine) RegisterNode(node NodeInfo, ctx context.Context) (err error) {
 	var sid string
 	var now = time.Now()
 
@@ -170,13 +158,13 @@ func (e *ConsulEngine) RegisterNode(node NodeInfo) (err error) {
 		e.nodes[k] = n
 		e.mutex.Unlock()
 
-		if sid, err = e.createSession(e.nodeTimeout); err != nil {
+		if sid, err = e.createSession(e.nodeTimeout, ctx); err != nil {
 			n.err = err
 		} else {
 			n.sid = sid
 		}
 
-		if err = e.registerNode(node, sid); err != nil {
+		if err = e.registerNode(node, sid, ctx); err != nil {
 			n.sid = ""
 			n.err = err
 		}
@@ -193,7 +181,7 @@ func (e *ConsulEngine) RegisterNode(node NodeInfo) (err error) {
 	return
 }
 
-func (e *ConsulEngine) UnregisterNode(node NodeInfo) (err error) {
+func (e *ConsulEngine) UnregisterNode(node NodeInfo, ctx context.Context) (err error) {
 	var sid string
 	var now = time.Now()
 
@@ -205,13 +193,13 @@ func (e *ConsulEngine) UnregisterNode(node NodeInfo) (err error) {
 		e.mutex.Lock()
 		delete(e.nodes, sid)
 		e.mutex.Unlock()
-		err = e.destroySession(sid)
+		err = e.destroySession(sid, ctx)
 	}
 
 	return
 }
 
-func (e *ConsulEngine) PingNode(node NodeInfo) (err error) {
+func (e *ConsulEngine) PingNode(node NodeInfo, ctx context.Context) (err error) {
 	var sid string
 	var now = time.Now()
 
@@ -222,13 +210,13 @@ func (e *ConsulEngine) PingNode(node NodeInfo) (err error) {
 	if len(sid) == 0 {
 		err = errMissingNode
 	} else {
-		err = e.renewSession(sid)
+		err = e.renewSession(sid, ctx)
 	}
 
 	return
 }
 
-func (e *ConsulEngine) TombstoneTopic(node NodeInfo, topic string) (err error) {
+func (e *ConsulEngine) TombstoneTopic(node NodeInfo, topic string, ctx context.Context) (err error) {
 	var sid string
 	var now = time.Now()
 	var exp = now.Add(e.tombTimeout)
@@ -243,15 +231,15 @@ func (e *ConsulEngine) TombstoneTopic(node NodeInfo, topic string) (err error) {
 	}
 
 	// Create a new session to manage the tombstone key's timeout independently.
-	if sid, err = e.createSession(e.tombTimeout); err != nil {
+	if sid, err = e.createSession(e.tombTimeout, ctx); err != nil {
 		return
 	}
 
-	err = e.tombstoneTopic(node, topic, sid, exp.UTC())
+	err = e.tombstoneTopic(node, topic, sid, exp.UTC(), ctx)
 	return
 }
 
-func (e *ConsulEngine) RegisterTopic(node NodeInfo, topic string) (err error) {
+func (e *ConsulEngine) RegisterTopic(node NodeInfo, topic string, ctx context.Context) (err error) {
 	var sid string
 	var now = time.Now()
 
@@ -262,13 +250,13 @@ func (e *ConsulEngine) RegisterTopic(node NodeInfo, topic string) (err error) {
 	if len(sid) == 0 {
 		err = errMissingNode
 	} else {
-		err = e.registerTopic(node, topic, sid)
+		err = e.registerTopic(node, topic, sid, ctx)
 	}
 
 	return
 }
 
-func (e *ConsulEngine) UnregisterTopic(node NodeInfo, topic string) (err error) {
+func (e *ConsulEngine) UnregisterTopic(node NodeInfo, topic string, ctx context.Context) (err error) {
 	var sid string
 	var now = time.Now()
 
@@ -279,7 +267,7 @@ func (e *ConsulEngine) UnregisterTopic(node NodeInfo, topic string) (err error) 
 	if len(sid) == 0 {
 		err = errMissingNode
 	} else {
-		err = e.unregisterTopic(node, topic)
+		err = e.unregisterTopic(node, topic, ctx)
 	}
 
 	if consulErrorNotFound(err) {
@@ -289,7 +277,7 @@ func (e *ConsulEngine) UnregisterTopic(node NodeInfo, topic string) (err error) 
 	return
 }
 
-func (e *ConsulEngine) RegisterChannel(node NodeInfo, topic string, channel string) (err error) {
+func (e *ConsulEngine) RegisterChannel(node NodeInfo, topic string, channel string, ctx context.Context) (err error) {
 	var sid string
 	var now = time.Now()
 
@@ -302,15 +290,15 @@ func (e *ConsulEngine) RegisterChannel(node NodeInfo, topic string, channel stri
 		return
 	}
 
-	if err = e.registerTopic(node, topic, sid); err != nil {
+	if err = e.registerTopic(node, topic, sid, ctx); err != nil {
 		return
 	}
 
-	err = e.registerChannel(node, topic, channel, sid)
+	err = e.registerChannel(node, topic, channel, sid, ctx)
 	return
 }
 
-func (e *ConsulEngine) UnregisterChannel(node NodeInfo, topic string, channel string) (err error) {
+func (e *ConsulEngine) UnregisterChannel(node NodeInfo, topic string, channel string, ctx context.Context) (err error) {
 	var sid string
 	var now = time.Now()
 
@@ -321,7 +309,7 @@ func (e *ConsulEngine) UnregisterChannel(node NodeInfo, topic string, channel st
 	if len(sid) == 0 {
 		err = errMissingNode
 	} else {
-		err = e.unregisterChannel(node, topic, channel)
+		err = e.unregisterChannel(node, topic, channel, ctx)
 	}
 
 	if consulErrorNotFound(err) {
@@ -331,11 +319,11 @@ func (e *ConsulEngine) UnregisterChannel(node NodeInfo, topic string, channel st
 	return
 }
 
-func (e *ConsulEngine) LookupNodes() ([]NodeInfo, error) {
-	return e.getNodes("nodes", time.Now())
+func (e *ConsulEngine) LookupNodes(ctx context.Context) ([]NodeInfo, error) {
+	return e.getNodes("nodes", time.Now(), ctx)
 }
 
-func (e *ConsulEngine) LookupProducers(topic string) (producers []NodeInfo, err error) {
+func (e *ConsulEngine) LookupProducers(topic string, ctx context.Context) (producers []NodeInfo, err error) {
 	now := time.Now()
 
 	resChan1 := make(chan []NodeInfo)
@@ -345,7 +333,7 @@ func (e *ConsulEngine) LookupProducers(topic string) (producers []NodeInfo, err 
 	errChan2 := make(chan error)
 
 	lookup := func(key string, res chan<- []NodeInfo, err chan<- error) {
-		if n, e := e.getNodes(key, now); e != nil {
+		if n, e := e.getNodes(key, now, ctx); e != nil {
 			err <- e
 		} else {
 			res <- n
@@ -386,8 +374,8 @@ searchProducers:
 	return
 }
 
-func (e *ConsulEngine) LookupTopics() (topics []string, err error) {
-	topics, err = e.listKeys("topics")
+func (e *ConsulEngine) LookupTopics(ctx context.Context) (topics []string, err error) {
+	topics, err = e.listKeys("topics", ctx)
 
 	if consulErrorNotFound(err) {
 		err = nil
@@ -396,8 +384,8 @@ func (e *ConsulEngine) LookupTopics() (topics []string, err error) {
 	return
 }
 
-func (e *ConsulEngine) LookupChannels(topic string) (channels []string, err error) {
-	channels, err = e.listKeys(path.Join("topics", topic, "channels"))
+func (e *ConsulEngine) LookupChannels(topic string, ctx context.Context) (channels []string, err error) {
+	channels, err = e.listKeys(path.Join("topics", topic, "channels"), ctx)
 
 	if consulErrorNotFound(err) {
 		err = nil
@@ -406,13 +394,13 @@ func (e *ConsulEngine) LookupChannels(topic string) (channels []string, err erro
 	return
 }
 
-func (e *ConsulEngine) LookupInfo() (info EngineInfo, err error) {
+func (e *ConsulEngine) LookupInfo(ctx context.Context) (info EngineInfo, err error) {
 	info.Type = "consul"
 	info.Version = "0.3.8"
 	return
 }
 
-func (e *ConsulEngine) CheckHealth() (err error) {
+func (e *ConsulEngine) CheckHealth(ctx context.Context) (err error) {
 	return
 }
 
@@ -437,7 +425,7 @@ func (e *ConsulEngine) session(node NodeInfo, now time.Time) (sid string, err er
 	return
 }
 
-func (e *ConsulEngine) createSession(ttl time.Duration) (sid string, err error) {
+func (e *ConsulEngine) createSession(ttl time.Duration, ctx context.Context) (sid string, err error) {
 	const minTTL = time.Second * 10
 	const maxTTL = time.Second * 86400
 
@@ -459,7 +447,7 @@ func (e *ConsulEngine) createSession(ttl time.Duration) (sid string, err error) 
 		Name:      "nsqlookupd consul engine",
 		Behavior:  "delete",
 		TTL:       strconv.Itoa(int(ttl.Seconds())) + "s",
-	}, &session); err != nil {
+	}, &session, ctx); err != nil {
 		return
 	}
 
@@ -467,40 +455,40 @@ func (e *ConsulEngine) createSession(ttl time.Duration) (sid string, err error) 
 	return
 }
 
-func (e *ConsulEngine) destroySession(sid string) error {
-	return e.put("/v1/session/destroy/"+sid, nil, nil)
+func (e *ConsulEngine) destroySession(sid string, ctx context.Context) error {
+	return e.put("/v1/session/destroy/"+sid, nil, nil, ctx)
 }
 
-func (e *ConsulEngine) renewSession(sid string) error {
-	return e.put("/v1/session/renew/"+sid, nil, nil)
+func (e *ConsulEngine) renewSession(sid string, ctx context.Context) error {
+	return e.put("/v1/session/renew/"+sid, nil, nil, ctx)
 }
 
-func (e *ConsulEngine) registerNode(node NodeInfo, sid string) error {
-	return e.setKey(consulNodeKey(node), sid, consulValue{Node: node})
+func (e *ConsulEngine) registerNode(node NodeInfo, sid string, ctx context.Context) error {
+	return e.setKey(consulNodeKey(node), sid, consulValue{Node: node}, ctx)
 }
 
-func (e *ConsulEngine) registerTopic(node NodeInfo, topic string, sid string) error {
-	return e.setKey(consulTopicKey(node, topic), sid, consulValue{Node: node})
+func (e *ConsulEngine) registerTopic(node NodeInfo, topic string, sid string, ctx context.Context) error {
+	return e.setKey(consulTopicKey(node, topic), sid, consulValue{Node: node}, ctx)
 }
 
-func (e *ConsulEngine) unregisterTopic(node NodeInfo, topic string) error {
-	return e.unsetKey(consulTopicKey(node, topic))
+func (e *ConsulEngine) unregisterTopic(node NodeInfo, topic string, ctx context.Context) error {
+	return e.unsetKey(consulTopicKey(node, topic), ctx)
 }
 
-func (e *ConsulEngine) registerChannel(node NodeInfo, topic string, channel string, sid string) error {
-	return e.setKey(consulChannelKey(node, topic, channel), sid, consulValue{Node: node})
+func (e *ConsulEngine) registerChannel(node NodeInfo, topic string, channel string, sid string, ctx context.Context) error {
+	return e.setKey(consulChannelKey(node, topic, channel), sid, consulValue{Node: node}, ctx)
 }
 
-func (e *ConsulEngine) unregisterChannel(node NodeInfo, topic string, channel string) error {
-	return e.unsetKey(consulChannelKey(node, topic, channel))
+func (e *ConsulEngine) unregisterChannel(node NodeInfo, topic string, channel string, ctx context.Context) error {
+	return e.unsetKey(consulChannelKey(node, topic, channel), ctx)
 }
 
-func (e *ConsulEngine) tombstoneTopic(node NodeInfo, topic string, sid string, exp time.Time) error {
-	return e.setKey(consulTombstoneKey(node, topic), sid, consulValue{Node: node, Deadline: &exp})
+func (e *ConsulEngine) tombstoneTopic(node NodeInfo, topic string, sid string, exp time.Time, ctx context.Context) error {
+	return e.setKey(consulTombstoneKey(node, topic), sid, consulValue{Node: node, Deadline: &exp}, ctx)
 }
 
-func (e *ConsulEngine) listKeys(prefix string) (keys []string, err error) {
-	if err = e.get(e.key(prefix)+"?keys", &keys); err != nil {
+func (e *ConsulEngine) listKeys(prefix string, ctx context.Context) (keys []string, err error) {
+	if err = e.get(e.key(prefix)+"?keys", &keys, ctx); err != nil {
 		return
 	}
 
@@ -523,10 +511,10 @@ func (e *ConsulEngine) listKeys(prefix string) (keys []string, err error) {
 	return
 }
 
-func (e *ConsulEngine) getNodes(key string, now time.Time) (nodes []NodeInfo, err error) {
+func (e *ConsulEngine) getNodes(key string, now time.Time, ctx context.Context) (nodes []NodeInfo, err error) {
 	var values []consulValue
 
-	if values, err = e.getKey(key); err != nil {
+	if values, err = e.getKey(key, ctx); err != nil {
 		if consulErrorNotFound(err) {
 			err = nil
 		}
@@ -556,10 +544,10 @@ func (e *ConsulEngine) getNodes(key string, now time.Time) (nodes []NodeInfo, er
 	return
 }
 
-func (e *ConsulEngine) getKey(key string) (values []consulValue, err error) {
+func (e *ConsulEngine) getKey(key string, ctx context.Context) (values []consulValue, err error) {
 	var kv []struct{ Value []byte }
 
-	if err = e.get(e.key(key)+"?recurse", &kv); err != nil {
+	if err = e.get(e.key(key)+"?recurse", &kv, ctx); err != nil {
 		return
 	}
 
@@ -579,31 +567,31 @@ func (e *ConsulEngine) getKey(key string) (values []consulValue, err error) {
 	return
 }
 
-func (e *ConsulEngine) setKey(key string, sid string, value consulValue) (err error) {
-	return e.put(e.key(key)+"?acquire="+sid, value, nil)
+func (e *ConsulEngine) setKey(key string, sid string, value consulValue, ctx context.Context) (err error) {
+	return e.put(e.key(key)+"?acquire="+sid, value, nil, ctx)
 }
 
-func (e *ConsulEngine) unsetKey(key string) error {
-	return e.delete(e.key(key) + "?recurse")
+func (e *ConsulEngine) unsetKey(key string, ctx context.Context) error {
+	return e.delete(e.key(key)+"?recurse", ctx)
 }
 
 func (e *ConsulEngine) key(key string) string {
 	return path.Join("/v1/kv", e.namespace, key)
 }
 
-func (e *ConsulEngine) get(url string, recv interface{}) error {
-	return e.do("GET", url, nil, recv)
+func (e *ConsulEngine) get(url string, recv interface{}, ctx context.Context) error {
+	return e.do("GET", url, nil, recv, ctx)
 }
 
-func (e *ConsulEngine) put(url string, send interface{}, recv interface{}) error {
-	return e.do("PUT", url, send, recv)
+func (e *ConsulEngine) put(url string, send interface{}, recv interface{}, ctx context.Context) error {
+	return e.do("PUT", url, send, recv, ctx)
 }
 
-func (e *ConsulEngine) delete(url string) error {
-	return e.do("DELETE", url, nil, nil)
+func (e *ConsulEngine) delete(url string, ctx context.Context) error {
+	return e.do("DELETE", url, nil, nil, ctx)
 }
 
-func (e *ConsulEngine) do(method string, url string, send interface{}, recv interface{}) (err error) {
+func (e *ConsulEngine) do(method string, url string, send interface{}, recv interface{}, ctx context.Context) (err error) {
 	var req *http.Request
 	var res *http.Response
 	var b []byte
@@ -626,6 +614,10 @@ func (e *ConsulEngine) do(method string, url string, send interface{}, recv inte
 
 	if req, err = http.NewRequest(method, url, bytes.NewReader(b)); err != nil {
 		return
+	}
+
+	if ctx != nil {
+		req = req.WithContext(ctx)
 	}
 
 	if res, err = e.client.Do(req); err != nil {

--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -110,7 +110,7 @@ func (e *ConsulEngine) Close() (err error) {
 		e.nodes = nil
 		e.mutex.Unlock()
 
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(DefaultEngineTimeout))
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultEngineTimeout)
 		defer cancel()
 
 		join := &sync.WaitGroup{}

--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -327,11 +327,11 @@ func (e *ConsulEngine) LookupNodes(ctx context.Context) ([]NodeInfo, error) {
 func (e *ConsulEngine) LookupProducers(ctx context.Context, topic string) (producers []NodeInfo, err error) {
 	now := time.Now()
 
-	resChan1 := make(chan []NodeInfo, 1)
-	resChan2 := make(chan []NodeInfo, 1)
+	resChan1 := make(chan []NodeInfo)
+	resChan2 := make(chan []NodeInfo)
 
-	errChan1 := make(chan error, 1)
-	errChan2 := make(chan error, 1)
+	errChan1 := make(chan error)
+	errChan2 := make(chan error)
 
 	lookup := func(key string, res chan<- []NodeInfo, err chan<- error) {
 		if n, e := e.getNodes(ctx, key, now); e != nil {

--- a/nsqlookup/engine.go
+++ b/nsqlookup/engine.go
@@ -42,7 +42,7 @@ type EngineInfo struct {
 // The Engine interface must be implemented by types that are intended to be
 // used to power nsqlookup servers.
 //
-// Each method of the engine accepts a context as last argument which may be
+// Each method of the engine accepts a context as first argument which may be
 // used to cancel or set a deadline on the operation.
 // This is useful for engines that work we storage services accessed over the
 // network.
@@ -54,48 +54,48 @@ type Engine interface {
 
 	// RegisterNode is called by nsqlookup servers when a new node is attempting
 	// to register.
-	RegisterNode(node NodeInfo, ctx context.Context) error
+	RegisterNode(ctx context.Context, node NodeInfo) error
 
 	// UnregisterNode is called by nsqlookup servers when a node that had
 	// previously registered is going away.
-	UnregisterNode(node NodeInfo, ctx context.Context) error
+	UnregisterNode(ctx context.Context, node NodeInfo) error
 
 	// PingNode is called by nsqlookup servers when a registered node sends a
 	// ping command to inform that it is still alive.
-	PingNode(node NodeInfo, ctx context.Context) error
+	PingNode(ctx context.Context, node NodeInfo) error
 
 	// TombstoneTopic marks topic as tombstoned on node.
-	TombstoneTopic(node NodeInfo, topic string, ctx context.Context) error
+	TombstoneTopic(ctx context.Context, node NodeInfo, topic string) error
 
 	// RegisterTopic is called by nsqlookup servers when topic is being
 	// registered on node.
-	RegisterTopic(node NodeInfo, topic string, ctx context.Context) error
+	RegisterTopic(ctx context.Context, node NodeInfo, topic string) error
 
 	// UnregisterTopic is called by nsqlookup servers when topic is being
 	// unregistered from node.
-	UnregisterTopic(node NodeInfo, topic string, ctx context.Context) error
+	UnregisterTopic(ctx context.Context, node NodeInfo, topic string) error
 
 	// RegisterChannel is called by nsqlookup servers when channel from topic is
 	// being registered on node.
-	RegisterChannel(node NodeInfo, topic string, channel string, ctx context.Context) error
+	RegisterChannel(ctx context.Context, node NodeInfo, topic string, channel string) error
 
 	// UnregisterChannel is called by nsqlookup servers when channel from topic
 	// is being unregistered from node.
-	UnregisterChannel(node NodeInfo, topic string, channel string, ctx context.Context) error
+	UnregisterChannel(ctx context.Context, node NodeInfo, topic string, channel string) error
 
 	// LookupNodes must return a list of of all nodes registered on the engine.
 	LookupNodes(ctx context.Context) ([]NodeInfo, error)
 
 	// LookupProducers must return a list of all nodes for which topic has been
 	// registered on the engine and were not tombstoned.
-	LookupProducers(topic string, ctx context.Context) ([]NodeInfo, error)
+	LookupProducers(ctx context.Context, topic string) ([]NodeInfo, error)
 
 	// LookupTopics must return a list of all topics registered on the engine.
 	LookupTopics(ctx context.Context) ([]string, error)
 
 	// LookupChannels must return a list of all channels registerd for topic on
 	// the engine.
-	LookupChannels(topic string, ctx context.Context) ([]string, error)
+	LookupChannels(ctx context.Context, topic string) ([]string, error)
 
 	// LookupInfo must return information about the engine.
 	LookupInfo(ctx context.Context) (EngineInfo, error)

--- a/nsqlookup/engine_test.go
+++ b/nsqlookup/engine_test.go
@@ -52,7 +52,7 @@ func testEngine(t *testing.T, do func(context.Context, *testing.T, Engine)) {
 			e := test.New(fmt.Sprintf("nsqlookup-test-%08x", rand.Int()%0xFFFFFFFF))
 			defer e.Close()
 
-			c, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Second))
+			c, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 
 			if info, err := e.LookupInfo(c); err != nil {

--- a/nsqlookup/engine_test.go
+++ b/nsqlookup/engine_test.go
@@ -52,7 +52,7 @@ func testEngine(t *testing.T, do func(context.Context, *testing.T, Engine)) {
 			e := test.New(fmt.Sprintf("nsqlookup-test-%08x", rand.Int()%0xFFFFFFFF))
 			defer e.Close()
 
-			c, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			c, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
 			if info, err := e.LookupInfo(c); err != nil {

--- a/nsqlookup/error.go
+++ b/nsqlookup/error.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"time"
 )
 
 type Error struct {
@@ -91,4 +92,21 @@ func appendError(err error, e error) error {
 		return e
 	}
 	return errors.New(err.Error() + "; " + e.Error())
+}
+
+func backoff(attempt int, max time.Duration) time.Duration {
+	d := time.Duration(attempt*attempt) * 10 * time.Millisecond
+	if d > max {
+		d = max
+	}
+	return d
+}
+
+func sleep(d time.Duration, cancel <-chan struct{}) {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-cancel:
+	}
 }

--- a/nsqlookup/error.go
+++ b/nsqlookup/error.go
@@ -3,6 +3,7 @@ package nsqlookup
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -102,11 +103,11 @@ func backoff(attempt int, max time.Duration) time.Duration {
 	return d
 }
 
-func sleep(d time.Duration, cancel <-chan struct{}) {
+func sleep(ctx context.Context, d time.Duration) {
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	select {
 	case <-timer.C:
-	case <-cancel:
+	case <-ctx.Done():
 	}
 }

--- a/nsqlookup/handler.go
+++ b/nsqlookup/handler.go
@@ -493,16 +493,16 @@ func (h NodeHandler) ServeConn(ctx context.Context, conn net.Conn) {
 
 		switch c := cmd.(type) {
 		case Ping:
-			res, err = h.ping(node, engineContext(ctx))
+			res, err = h.ping(engineContext(ctx), node)
 
 		case Identify:
-			node, res, err = h.identify(node, c.Info, engineContext(ctx))
+			node, res, err = h.identify(engineContext(ctx), node, c.Info)
 
 		case Register:
-			res, err = h.register(node, c.Topic, c.Channel, engineContext(ctx))
+			res, err = h.register(engineContext(ctx), node, c.Topic, c.Channel)
 
 		case Unregister:
-			node, res, err = h.unregister(node, c.Topic, c.Channel, engineContext(ctx))
+			node, res, err = h.unregister(engineContext(ctx), node, c.Topic, c.Channel)
 
 		default:
 			res = Error{Code: ErrInvalid, Reason: "unknown command"}
@@ -527,7 +527,7 @@ func (h NodeHandler) ServeConn(ctx context.Context, conn net.Conn) {
 	}
 }
 
-func (h NodeHandler) identify(node NodeInfo, info NodeInfo, ctx context.Context) (id NodeInfo, res RawResponse, err error) {
+func (h NodeHandler) identify(ctx context.Context, node NodeInfo, info NodeInfo) (id NodeInfo, res RawResponse, err error) {
 	if node != (NodeInfo{}) {
 		id, err = node, errCannotIdentifyAgain
 		return
@@ -537,14 +537,14 @@ func (h NodeHandler) identify(node NodeInfo, info NodeInfo, ctx context.Context)
 	return
 }
 
-func (h NodeHandler) ping(node NodeInfo, ctx context.Context) (res OK, err error) {
+func (h NodeHandler) ping(ctx context.Context, node NodeInfo) (res OK, err error) {
 	if node != (NodeInfo{}) { // ping may arrive before identify
 		err = h.Engine.PingNode(ctx, node)
 	}
 	return
 }
 
-func (h NodeHandler) register(node NodeInfo, topic string, channel string, ctx context.Context) (res OK, err error) {
+func (h NodeHandler) register(ctx context.Context, node NodeInfo, topic string, channel string) (res OK, err error) {
 	if node == (NodeInfo{}) {
 		err = errClientMustIdentify
 		return
@@ -564,7 +564,7 @@ func (h NodeHandler) register(node NodeInfo, topic string, channel string, ctx c
 	return
 }
 
-func (h NodeHandler) unregister(node NodeInfo, topic string, channel string, ctx context.Context) (id NodeInfo, res OK, err error) {
+func (h NodeHandler) unregister(ctx context.Context, node NodeInfo, topic string, channel string) (id NodeInfo, res OK, err error) {
 	if node == (NodeInfo{}) {
 		err = errClientMustIdentify
 		return

--- a/nsqlookup/handler.go
+++ b/nsqlookup/handler.go
@@ -415,7 +415,7 @@ type NodeHandler struct {
 
 // ServeConn takes ownership of the conn object and starts service the commands
 // that the client sends to the discovery handler.
-func (h NodeHandler) ServeConn(conn net.Conn, ctx context.Context) {
+func (h NodeHandler) ServeConn(ctx context.Context, conn net.Conn) {
 	const bufSize = 2048
 
 	var node NodeInfo

--- a/nsqlookup/handler.go
+++ b/nsqlookup/handler.go
@@ -422,6 +422,18 @@ func (h NodeHandler) ServeConn(conn net.Conn, ctx context.Context) {
 	var r = bufio.NewReaderSize(conn, bufSize)
 	var w = bufio.NewWriterSize(conn, bufSize)
 
+	if h.ReadTimeout == 0 {
+		h.ReadTimeout = DefaultReadTimeout
+	}
+
+	if h.WriteTimeout == 0 {
+		h.WriteTimeout = DefaultWriteTimeout
+	}
+
+	if h.EngineTimeout == 0 {
+		h.EngineTimeout = DefaultEngineTimeout
+	}
+
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -454,14 +466,6 @@ func (h NodeHandler) ServeConn(conn net.Conn, ctx context.Context) {
 	if len(h.Info.Version) == 0 {
 		info, _ := h.Engine.LookupInfo(engineContext(ctx))
 		h.Info.Version = info.Version
-	}
-
-	if h.ReadTimeout == 0 {
-		h.ReadTimeout = DefaultReadTimeout
-	}
-
-	if h.WriteTimeout == 0 {
-		h.WriteTimeout = DefaultWriteTimeout
 	}
 
 	var cmdChan = make(chan Command)

--- a/nsqlookup/handler.go
+++ b/nsqlookup/handler.go
@@ -51,7 +51,7 @@ func (h APIHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		h.EngineTimeout = DefaultEngineTimeout
 	}
 
-	ctx, _ := context.WithDeadline(req.Context(), time.Now().Add(h.EngineTimeout))
+	ctx, _ := context.WithTimeout(req.Context(), h.EngineTimeout)
 	req = req.WithContext(ctx)
 
 	switch req.URL.Path {
@@ -439,7 +439,7 @@ func (h NodeHandler) ServeConn(conn net.Conn, ctx context.Context) {
 	}
 
 	engineContext := func(ctx context.Context) context.Context {
-		ctx, _ = context.WithDeadline(ctx, time.Now().Add(h.EngineTimeout))
+		ctx, _ = context.WithTimeout(ctx, h.EngineTimeout)
 		return ctx
 	}
 

--- a/nsqlookup/local.go
+++ b/nsqlookup/local.go
@@ -1,6 +1,7 @@
 package nsqlookup
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -77,7 +78,7 @@ func (e *LocalEngine) Close() error {
 	return nil
 }
 
-func (e *LocalEngine) RegisterNode(node NodeInfo) error {
+func (e *LocalEngine) RegisterNode(node NodeInfo, ctx context.Context) error {
 	now := time.Now()
 	exp := now.Add(e.nodeTimeout)
 	key := httpBroadcastAddress(node)
@@ -96,7 +97,7 @@ func (e *LocalEngine) RegisterNode(node NodeInfo) error {
 	return nil
 }
 
-func (e *LocalEngine) UnregisterNode(node NodeInfo) error {
+func (e *LocalEngine) UnregisterNode(node NodeInfo, ctx context.Context) error {
 	key := httpBroadcastAddress(node)
 	e.mutex.Lock()
 	delete(e.nodes, key)
@@ -104,12 +105,12 @@ func (e *LocalEngine) UnregisterNode(node NodeInfo) error {
 	return nil
 }
 
-func (e *LocalEngine) PingNode(node NodeInfo) error {
+func (e *LocalEngine) PingNode(node NodeInfo, ctx context.Context) error {
 	_, err := e.get(node)
 	return err
 }
 
-func (e *LocalEngine) TombstoneTopic(node NodeInfo, topic string) error {
+func (e *LocalEngine) TombstoneTopic(node NodeInfo, topic string, ctx context.Context) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.tombstoneTopic(topic, time.Now().Add(e.tombTimeout))
@@ -117,7 +118,7 @@ func (e *LocalEngine) TombstoneTopic(node NodeInfo, topic string) error {
 	return err
 }
 
-func (e *LocalEngine) RegisterTopic(node NodeInfo, topic string) error {
+func (e *LocalEngine) RegisterTopic(node NodeInfo, topic string, ctx context.Context) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.registerTopic(topic)
@@ -125,7 +126,7 @@ func (e *LocalEngine) RegisterTopic(node NodeInfo, topic string) error {
 	return err
 }
 
-func (e *LocalEngine) UnregisterTopic(node NodeInfo, topic string) error {
+func (e *LocalEngine) UnregisterTopic(node NodeInfo, topic string, ctx context.Context) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.unregisterTopic(topic)
@@ -133,7 +134,7 @@ func (e *LocalEngine) UnregisterTopic(node NodeInfo, topic string) error {
 	return err
 }
 
-func (e *LocalEngine) RegisterChannel(node NodeInfo, topic string, channel string) error {
+func (e *LocalEngine) RegisterChannel(node NodeInfo, topic string, channel string, ctx context.Context) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.registerChannel(topic, channel)
@@ -141,7 +142,7 @@ func (e *LocalEngine) RegisterChannel(node NodeInfo, topic string, channel strin
 	return err
 }
 
-func (e *LocalEngine) UnregisterChannel(node NodeInfo, topic string, channel string) error {
+func (e *LocalEngine) UnregisterChannel(node NodeInfo, topic string, channel string, ctx context.Context) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.unregisterChannel(topic, channel)
@@ -149,7 +150,7 @@ func (e *LocalEngine) UnregisterChannel(node NodeInfo, topic string, channel str
 	return err
 }
 
-func (e *LocalEngine) LookupNodes() (nodes []NodeInfo, err error) {
+func (e *LocalEngine) LookupNodes(ctx context.Context) (nodes []NodeInfo, err error) {
 	e.mutex.RLock()
 
 	for _, node := range e.nodes {
@@ -160,7 +161,7 @@ func (e *LocalEngine) LookupNodes() (nodes []NodeInfo, err error) {
 	return
 }
 
-func (e *LocalEngine) LookupProducers(topic string) (producers []NodeInfo, err error) {
+func (e *LocalEngine) LookupProducers(topic string, ctx context.Context) (producers []NodeInfo, err error) {
 	e.mutex.RLock()
 
 	for _, node := range e.nodes {
@@ -173,7 +174,7 @@ func (e *LocalEngine) LookupProducers(topic string) (producers []NodeInfo, err e
 	return
 }
 
-func (e *LocalEngine) LookupTopics() (topics []string, err error) {
+func (e *LocalEngine) LookupTopics(ctx context.Context) (topics []string, err error) {
 	set := make(map[string]bool)
 	e.mutex.RLock()
 
@@ -191,7 +192,7 @@ func (e *LocalEngine) LookupTopics() (topics []string, err error) {
 	return
 }
 
-func (e *LocalEngine) LookupChannels(topic string) (channels []string, err error) {
+func (e *LocalEngine) LookupChannels(topic string, ctx context.Context) (channels []string, err error) {
 	set := make(map[string]bool)
 	e.mutex.RLock()
 
@@ -209,13 +210,13 @@ func (e *LocalEngine) LookupChannels(topic string) (channels []string, err error
 	return
 }
 
-func (e *LocalEngine) LookupInfo() (info EngineInfo, err error) {
+func (e *LocalEngine) LookupInfo(ctx context.Context) (info EngineInfo, err error) {
 	info.Type = "local"
 	info.Version = "0.3.8"
 	return
 }
 
-func (e *LocalEngine) CheckHealth() (err error) {
+func (e *LocalEngine) CheckHealth(ctx context.Context) (err error) {
 	return
 }
 

--- a/nsqlookup/local.go
+++ b/nsqlookup/local.go
@@ -78,7 +78,7 @@ func (e *LocalEngine) Close() error {
 	return nil
 }
 
-func (e *LocalEngine) RegisterNode(node NodeInfo, ctx context.Context) error {
+func (e *LocalEngine) RegisterNode(ctx context.Context, node NodeInfo) error {
 	now := time.Now()
 	exp := now.Add(e.nodeTimeout)
 	key := httpBroadcastAddress(node)
@@ -97,7 +97,7 @@ func (e *LocalEngine) RegisterNode(node NodeInfo, ctx context.Context) error {
 	return nil
 }
 
-func (e *LocalEngine) UnregisterNode(node NodeInfo, ctx context.Context) error {
+func (e *LocalEngine) UnregisterNode(ctx context.Context, node NodeInfo) error {
 	key := httpBroadcastAddress(node)
 	e.mutex.Lock()
 	delete(e.nodes, key)
@@ -105,12 +105,12 @@ func (e *LocalEngine) UnregisterNode(node NodeInfo, ctx context.Context) error {
 	return nil
 }
 
-func (e *LocalEngine) PingNode(node NodeInfo, ctx context.Context) error {
+func (e *LocalEngine) PingNode(ctx context.Context, node NodeInfo) error {
 	_, err := e.get(node)
 	return err
 }
 
-func (e *LocalEngine) TombstoneTopic(node NodeInfo, topic string, ctx context.Context) error {
+func (e *LocalEngine) TombstoneTopic(ctx context.Context, node NodeInfo, topic string) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.tombstoneTopic(topic, time.Now().Add(e.tombTimeout))
@@ -118,7 +118,7 @@ func (e *LocalEngine) TombstoneTopic(node NodeInfo, topic string, ctx context.Co
 	return err
 }
 
-func (e *LocalEngine) RegisterTopic(node NodeInfo, topic string, ctx context.Context) error {
+func (e *LocalEngine) RegisterTopic(ctx context.Context, node NodeInfo, topic string) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.registerTopic(topic)
@@ -126,7 +126,7 @@ func (e *LocalEngine) RegisterTopic(node NodeInfo, topic string, ctx context.Con
 	return err
 }
 
-func (e *LocalEngine) UnregisterTopic(node NodeInfo, topic string, ctx context.Context) error {
+func (e *LocalEngine) UnregisterTopic(ctx context.Context, node NodeInfo, topic string) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.unregisterTopic(topic)
@@ -134,7 +134,7 @@ func (e *LocalEngine) UnregisterTopic(node NodeInfo, topic string, ctx context.C
 	return err
 }
 
-func (e *LocalEngine) RegisterChannel(node NodeInfo, topic string, channel string, ctx context.Context) error {
+func (e *LocalEngine) RegisterChannel(ctx context.Context, node NodeInfo, topic string, channel string) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.registerChannel(topic, channel)
@@ -142,7 +142,7 @@ func (e *LocalEngine) RegisterChannel(node NodeInfo, topic string, channel strin
 	return err
 }
 
-func (e *LocalEngine) UnregisterChannel(node NodeInfo, topic string, channel string, ctx context.Context) error {
+func (e *LocalEngine) UnregisterChannel(ctx context.Context, node NodeInfo, topic string, channel string) error {
 	n, err := e.get(node)
 	if n != nil {
 		n.unregisterChannel(topic, channel)
@@ -161,7 +161,7 @@ func (e *LocalEngine) LookupNodes(ctx context.Context) (nodes []NodeInfo, err er
 	return
 }
 
-func (e *LocalEngine) LookupProducers(topic string, ctx context.Context) (producers []NodeInfo, err error) {
+func (e *LocalEngine) LookupProducers(ctx context.Context, topic string) (producers []NodeInfo, err error) {
 	e.mutex.RLock()
 
 	for _, node := range e.nodes {
@@ -192,7 +192,7 @@ func (e *LocalEngine) LookupTopics(ctx context.Context) (topics []string, err er
 	return
 }
 
-func (e *LocalEngine) LookupChannels(topic string, ctx context.Context) (channels []string, err error) {
+func (e *LocalEngine) LookupChannels(ctx context.Context, topic string) (channels []string, err error) {
 	set := make(map[string]bool)
 	e.mutex.RLock()
 


### PR DESCRIPTION
@yields 
@calvinfo 
@rbranson 
@thehydroimpulse 

I revisited the code to support passing a cancellation context to the nsqlookup engines, this helps setting deadlines on engine operations or cancelling in-flight operations when clients are unexpectedly going away.

Please take a look and let me know if anything should be changed.