### PR TITLE
use an unbuffered channel as output to the RateLimit function

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,7 @@ test:
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
+      go.test='govendor test -v -cover +local'
 
 deployment:
   release:

--- a/consumer.go
+++ b/consumer.go
@@ -301,14 +301,17 @@ func (c *Consumer) approximateRdyCount() (count int) {
 
 // RateLimit consumes messages from the messages channel and limits the rate at
 // which they are produced to the channel returned by this function.
+//
 // The limit is the maximum number of messages per second that are produced.
 // No rate limit is applied if limit is negative or zero.
+//
+// The returned channel is closed when the messages channel is closed.
 func RateLimit(limit int, messages <-chan Message) <-chan Message {
 	if limit <= 0 {
 		return messages
 	}
 
-	output := make(chan Message, cap(messages))
+	output := make(chan Message)
 
 	go func() {
 		ticker := time.NewTicker(1 * time.Second)


### PR DESCRIPTION
@thehydroimpulse 
@yields 
@calvinfo 

I introduced this function yesterday for the nsq-to-nsq rewrite, but I made a mistake on the output channel capacity.

I believe the right approach is to use an unbuffered channel because then we control how fast the consumer reads, not how fast we produce messages that become available.

For example, if we set the limit to 10 msg/sec, then the channel capacity is 100, we can spend 10 seconds writing messages to the output channel. When a consumer starts reading messages it may get 100 messages right away which breaks the rate limit we were trying to enforce.

Please take a look and let me know if you have any concerns.