### PR TITLE
add nsqlookupd implementation with support for a consul backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _testmain.go
 # govendor
 /vendor/*/
 nsq-to-nsq
+nsqlookupd

--- a/cmd/nsqlookupd/main.go
+++ b/cmd/nsqlookupd/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/segmentio/conf"
+	"github.com/segmentio/netx"
+	"github.com/segmentio/nsq-go/nsqlookup"
+)
+
+func main() {
+	hostname, _ := os.Hostname()
+
+	config := struct {
+		HTTPAddress             net.TCPAddr   `conf:"http-address" help:"<addr>:<port> to listen on for HTTP clients"`
+		TCPAddress              net.TCPAddr   `conf:"tcp-address" help:"<addr>:<port> to listen on for TCP clients"`
+		BroadcastAddress        string        `conf:"broadcast-address" help:"external address of this lookupd node, (default to the OS hostname)"`
+		TombstoneLifetime       time.Duration `conf:"tombstone-lifetime" help:"duration of time a producer will remain tombstoned if registration remains"`
+		InactiveProducerTimeout time.Duration `conf:"inactive-producer-timeout" help:"duration of time a producer will remain in the active list since its last ping"`
+		Verbose                 bool          `conf:"verbose" help:"enable verbose logging"`
+		Version                 bool          `conf:"version" help:"print version string"`
+	}{
+		HTTPAddress:             net.TCPAddr{IP: net.IPv4(0, 0, 0, 0), Port: 4161},
+		TCPAddress:              net.TCPAddr{IP: net.IPv4(0, 0, 0, 0), Port: 4160},
+		BroadcastAddress:        hostname,
+		TombstoneLifetime:       42 * time.Second,
+		InactiveProducerTimeout: 1 * time.Minute,
+	}
+
+	var args = conf.Load(&config)
+	var engine nsqlookup.Engine
+
+	if len(args) == 0 {
+		log.Print("using local nsqlookup engine")
+		engine = nsqlookup.NewLocalEngine(nsqlookup.LocalConfig{
+			NodeTimeout:      config.InactiveProducerTimeout,
+			TombstoneTimeout: config.TombstoneLifetime,
+		})
+
+	} else if len(args) == 1 {
+		arg := args[0]
+		switch {
+		case strings.HasPrefix(arg, "consul://"):
+			log.Print("using consul nsqlookup engine")
+			engine = nsqlookup.NewConsulEngine(nsqlookup.ConsulConfig{
+				Address:          arg[9:],
+				NodeTimeout:      config.InactiveProducerTimeout,
+				TombstoneTimeout: config.TombstoneLifetime,
+			})
+
+		default:
+			log.Fatalf("unsupported engine: %s", arg)
+		}
+
+	} else {
+		log.Fatal("too many arguments")
+	}
+
+	errchan := make(chan error)
+	sigchan := make(chan os.Signal)
+	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
+
+	go func(addr string) {
+		log.Printf("starting http server on %s", addr)
+		errchan <- http.ListenAndServe(addr, nsqlookup.HTTPHandler{
+			Engine: engine,
+		})
+	}(config.HTTPAddress.String())
+
+	go func(addr string) {
+		log.Printf("starting tcp server on %s", addr)
+		errchan <- netx.ListenAndServe(addr, nsqlookup.TCPHandler{
+			Engine: engine,
+			Info: nsqlookup.NodeInfo{
+				Hostname:         hostname,
+				BroadcastAddress: config.BroadcastAddress,
+			},
+		})
+	}(config.TCPAddress.String())
+
+	select {
+	case <-sigchan:
+	case err := <-errchan:
+		log.Fatal(err)
+	}
+}

--- a/cmd/nsqlookupd/main.go
+++ b/cmd/nsqlookupd/main.go
@@ -19,13 +19,13 @@ func main() {
 	hostname, _ := os.Hostname()
 
 	config := struct {
-		HTTPAddress             net.TCPAddr   `conf:"http-address" help:"<addr>:<port> to listen on for HTTP clients"`
-		TCPAddress              net.TCPAddr   `conf:"tcp-address" help:"<addr>:<port> to listen on for TCP clients"`
-		BroadcastAddress        string        `conf:"broadcast-address" help:"external address of this lookupd node, (default to the OS hostname)"`
-		TombstoneLifetime       time.Duration `conf:"tombstone-lifetime" help:"duration of time a producer will remain tombstoned if registration remains"`
-		InactiveProducerTimeout time.Duration `conf:"inactive-producer-timeout" help:"duration of time a producer will remain in the active list since its last ping"`
-		Verbose                 bool          `conf:"verbose" help:"enable verbose logging"`
-		Version                 bool          `conf:"version" help:"print version string"`
+		HTTPAddress             net.TCPAddr   `conf:"http-address"               help:"<addr>:<port> to listen on for HTTP clients"`
+		TCPAddress              net.TCPAddr   `conf:"tcp-address"                help:"<addr>:<port> to listen on for TCP clients"`
+		BroadcastAddress        string        `conf:"broadcast-address"          help:"external address of this lookupd node, (default to the OS hostname)"`
+		TombstoneLifetime       time.Duration `conf:"tombstone-lifetime"         help:"duration of time a producer will remain tombstoned if registration remains"`
+		InactiveProducerTimeout time.Duration `conf:"inactive-producer-timeout"  help:"duration of time a producer will remain in the active list since its last ping"`
+		Verbose                 bool          `conf:"verbose"                    help:"enable verbose logging"`
+		Version                 bool          `conf:"version"                    help:"print version string"`
 	}{
 		HTTPAddress:             net.TCPAddr{IP: net.IPv4(0, 0, 0, 0), Port: 4161},
 		TCPAddress:              net.TCPAddr{IP: net.IPv4(0, 0, 0, 0), Port: 4160},

--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -210,8 +210,11 @@ func (e *ConsulEngine) PingNode(ctx context.Context, node NodeInfo) (err error) 
 
 	if len(sid) == 0 {
 		err = errMissingNode
-	} else {
-		err = e.renewSession(ctx, sid)
+		return
+	}
+
+	if err = e.renewSession(ctx, sid); err != nil {
+		e.destroySession(ctx, sid)
 	}
 
 	return
@@ -417,6 +420,7 @@ func (e *ConsulEngine) session(node NodeInfo, now time.Time) (sid string, err er
 	if n != nil {
 		n.mutex.RLock()
 		if !now.After(n.expTime) {
+			n.expTime = now.Add(e.nodeTimeout)
 			sid = n.sid
 			err = n.err
 		}

--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -191,8 +191,9 @@ func (e *ConsulEngine) UnregisterNode(ctx context.Context, node NodeInfo) (err e
 	}
 
 	if len(sid) != 0 {
+		key := httpBroadcastAddress(node)
 		e.mutex.Lock()
-		delete(e.nodes, sid)
+		delete(e.nodes, key)
 		e.mutex.Unlock()
 		err = e.destroySession(ctx, sid)
 	}
@@ -214,6 +215,10 @@ func (e *ConsulEngine) PingNode(ctx context.Context, node NodeInfo) (err error) 
 	}
 
 	if err = e.renewSession(ctx, sid); err != nil {
+		key := httpBroadcastAddress(node)
+		e.mutex.Lock()
+		delete(e.nodes, key)
+		e.mutex.Unlock()
 		e.destroySession(ctx, sid)
 	}
 

--- a/nsqlookup/engine.go
+++ b/nsqlookup/engine.go
@@ -30,6 +30,11 @@ type NodeInfo struct {
 	Version string `json:"version"`
 }
 
+// String returns a human-readable representation of the node info.
+func (info NodeInfo) String() string {
+	return httpBroadcastAddress(info)
+}
+
 // The EngineInfo structure carries information about a nsqlookup engine.
 type EngineInfo struct {
 	// Type of the engine.
@@ -120,6 +125,20 @@ func (n byNode) Less(i int, j int) bool {
 	n2 := &n[j]
 	return (n1.BroadcastAddress < n2.BroadcastAddress) ||
 		(n1.BroadcastAddress == n2.BroadcastAddress && n1.TcpPort < n2.TcpPort)
+}
+
+func nonNilNodes(n []NodeInfo) []NodeInfo {
+	if n == nil {
+		n = []NodeInfo{}
+	}
+	return n
+}
+
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		s = []string{}
+	}
+	return s
 }
 
 func sortedNodes(n []NodeInfo) []NodeInfo {

--- a/nsqlookup/error.go
+++ b/nsqlookup/error.go
@@ -15,10 +15,11 @@ type Error struct {
 }
 
 const (
-	ErrInvalid    = "E_INVALID"
-	ErrBadTopic   = "E_BAD_TOPIC"
-	ErrBadChannel = "E_BAD_CHANNEL"
-	ErrBadBody    = "E_BAD_BODY"
+	ErrInvalid     = "E_INVALID"
+	ErrBadTopic    = "E_BAD_TOPIC"
+	ErrBadChannel  = "E_BAD_CHANNEL"
+	ErrBadBody     = "E_BAD_BODY"
+	ErrBadProtocol = "E_BAD_PROTOCOL"
 )
 
 func (e Error) Error() string {
@@ -47,6 +48,10 @@ func makeErrBadChannel(s string, a ...interface{}) Error {
 
 func makeErrBadBody(s string, a ...interface{}) Error {
 	return makeError(ErrBadBody, s, a...)
+}
+
+func makeErrBadProtocol(s string, a ...interface{}) Error {
+	return makeError(ErrBadTopic, s, a...)
 }
 
 func makeError(c string, s string, a ...interface{}) Error {


### PR DESCRIPTION
@rbranson 
@calvinfo 
@yields 
@thehydroimpulse 

Hey guys, here's the plan coming together, I've done a bunch of tests locally to make sure it worked with with nsqd and nsqadmin, and that it was giving the same results than the standard nsqlookupd.

The next step plan is to run this side by side with our current nsqlookupd stack, then I'll write some integration tests to make sure the software behaves the same than the standard nsqlookupd. If everything goes as planned we can switch services to use the consul-based servers when we come back from the holidays.

Please take a look and let me know if anything should be changed.