### PR TITLE
Force connect

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -227,6 +227,10 @@ func (p *Producer) run() {
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
+	if p.forceConnect {
+		connect()
+	}
+
 	for {
 		select {
 		case <-p.done:


### PR DESCRIPTION
This PR adds the ability to force a producer to establish connections to nsqd instead of lazily connecting when messages are published.