### PR TITLE
add more logs to the producer

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -188,11 +188,17 @@ func (p *Producer) run() {
 			resChan = nil
 			pending = completeAllProducerRequests(pending, err)
 		}
+
+		if err != nil {
+			log.Printf("closing nsqd connection to %s: %s", p.address, err)
+		}
 	}
 
 	connect := func() (err error) {
+		log.Printf("opening nsqd connection to %s", p.address)
+
 		if conn, err = DialTimeout(p.address, p.dialTimeout); err != nil {
-			log.Printf("failed to connect to %s: %s", p.address, err)
+			log.Printf("failed to connect to nsqd at %s: %s", p.address, err)
 			return
 		}
 


### PR DESCRIPTION
Add a few more logs to get visibility into the lifecycle of producer connections (still investigating the occasional connection drops on tracking-api).