### PR TITLE
fix write timeout

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -300,7 +300,7 @@ func (p *Producer) flush(conn *Conn, resChan chan<- Frame) {
 }
 
 func (p *Producer) write(conn *Conn, cmd Command) (err error) {
-	if err = conn.SetDeadline(time.Now().Add(p.writeTimeout)); err == nil {
+	if err = conn.SetWriteDeadline(time.Now().Add(p.writeTimeout)); err == nil {
 		err = conn.WriteCommand(cmd)
 	}
 	return


### PR DESCRIPTION
While this was probably not happening in production due to high traffic it's definitely a bug, setting a global timeout for a write operation caused the read loop to timeout as well when traffic is low.
