### PR TITLE
refactor nsqlookup engines to fix race conditions

### DIFF
--- a/cmd/nsqlookupd/main.go
+++ b/cmd/nsqlookupd/main.go
@@ -65,11 +65,18 @@ func main() {
 		arg := args[0]
 		switch {
 		case strings.HasPrefix(arg, "consul://"):
+			var transport http.RoundTripper = http.DefaultTransport
+
+			if config.Verbose {
+				transport = events.NewTransport(nil, transport)
+			}
+
 			log.Print("using consul nsqlookup engine")
 			engine = nsqlookup.NewConsulEngine(nsqlookup.ConsulConfig{
 				Address:          arg[9:],
 				NodeTimeout:      config.InactiveProducerTimeout,
 				TombstoneTimeout: config.TombstoneLifetime,
+				Transport:        transport,
 			})
 
 		default:

--- a/cmd/nsqlookupd/main.go
+++ b/cmd/nsqlookupd/main.go
@@ -68,7 +68,7 @@ func main() {
 			var transport http.RoundTripper = http.DefaultTransport
 
 			if config.Verbose {
-				transport = events.NewTransport(nil, transport)
+				transport = httpevents.NewTransport(nil, transport)
 			}
 
 			log.Print("using consul nsqlookup engine")

--- a/cmd/nsqlookupd/main.go
+++ b/cmd/nsqlookupd/main.go
@@ -86,21 +86,33 @@ func main() {
 	signal.Notify(sigsend, syscall.SIGINT, syscall.SIGTERM)
 
 	go func(addr string) {
-		log.Printf("starting http server on %s", addr)
-		errchan <- http.ListenAndServe(addr, httpstats.NewHandler(nil, httpevents.NewHandler(nil, nsqlookup.HTTPHandler{
+		var handler http.Handler = nsqlookup.HTTPHandler{
 			Engine: engine,
-		})))
+		}
+
+		if config.Verbose {
+			handler = httpevents.NewHandler(nil, handler)
+		}
+
+		log.Printf("starting http server on %s", addr)
+		errchan <- http.ListenAndServe(addr, httpstats.NewHandler(nil, handler))
 	}(config.HTTPAddress.String())
 
 	go func(addr string) {
-		log.Printf("starting tcp server on %s", addr)
-		errchan <- netx.ListenAndServe(addr, netstats.NewHandler(nil, netevents.NewHandler(nil, nsqlookup.TCPHandler{
+		var handler netx.Handler = nsqlookup.TCPHandler{
 			Engine: engine,
 			Info: nsqlookup.NodeInfo{
 				Hostname:         hostname,
 				BroadcastAddress: config.BroadcastAddress,
 			},
-		})))
+		}
+
+		if config.Verbose {
+			handler = netevents.NewHandler(nil, handler)
+		}
+
+		log.Printf("starting tcp server on %s", addr)
+		errchan <- netx.ListenAndServe(addr, netstats.NewHandler(nil, handler))
 	}(config.TCPAddress.String())
 
 	select {

--- a/cmd/nsqlookupd/vendor/vendor.json
+++ b/cmd/nsqlookupd/vendor/vendor.json
@@ -57,18 +57,6 @@
 			"revisionTime": "2017-01-07T03:28:07Z"
 		},
 		{
-			"checksumSHA1": "KWe+WZJa4DpenhFb16gFglOQKjk=",
-			"path": "github.com/segmentio/nsq-go",
-			"revision": "bf4c9c2a1a77a6fa09d5a94cc1428716d7fd5337",
-			"revisionTime": "2017-01-03T05:57:29Z"
-		},
-		{
-			"checksumSHA1": "hEPin9t7u3pYQBhm2Q/XjpWVqNU=",
-			"path": "github.com/segmentio/nsq-go/nsqlookup",
-			"revision": "bf4c9c2a1a77a6fa09d5a94cc1428716d7fd5337",
-			"revisionTime": "2017-01-03T05:57:29Z"
-		},
-		{
 			"checksumSHA1": "8V1hshQRIil6YSOiRBfj7YX2BeY=",
 			"path": "github.com/segmentio/objconv",
 			"revision": "07e72d5ac00fa942ec00bc58fae3d11000c4834b",

--- a/nsqlookup/consul.go
+++ b/nsqlookup/consul.go
@@ -443,7 +443,7 @@ func newConsulNode(eng *ConsulEngine, sid string, info NodeInfo) *ConsulNode {
 }
 
 func (n *ConsulNode) String() string {
-	return n.info.String()
+	return n.info.String() + "/" + n.sid
 }
 
 func (n *ConsulNode) Info() NodeInfo {

--- a/nsqlookup/engine.go
+++ b/nsqlookup/engine.go
@@ -59,34 +59,10 @@ type Engine interface {
 
 	// RegisterNode is called by nsqlookup servers when a new node is attempting
 	// to register.
-	RegisterNode(ctx context.Context, node NodeInfo) error
-
-	// UnregisterNode is called by nsqlookup servers when a node that had
-	// previously registered is going away.
-	UnregisterNode(ctx context.Context, node NodeInfo) error
-
-	// PingNode is called by nsqlookup servers when a registered node sends a
-	// ping command to inform that it is still alive.
-	PingNode(ctx context.Context, node NodeInfo) error
+	RegisterNode(ctx context.Context, node NodeInfo) (Node, error)
 
 	// TombstoneTopic marks topic as tombstoned on node.
 	TombstoneTopic(ctx context.Context, node NodeInfo, topic string) error
-
-	// RegisterTopic is called by nsqlookup servers when topic is being
-	// registered on node.
-	RegisterTopic(ctx context.Context, node NodeInfo, topic string) error
-
-	// UnregisterTopic is called by nsqlookup servers when topic is being
-	// unregistered from node.
-	UnregisterTopic(ctx context.Context, node NodeInfo, topic string) error
-
-	// RegisterChannel is called by nsqlookup servers when channel from topic is
-	// being registered on node.
-	RegisterChannel(ctx context.Context, node NodeInfo, topic string, channel string) error
-
-	// UnregisterChannel is called by nsqlookup servers when channel from topic
-	// is being unregistered from node.
-	UnregisterChannel(ctx context.Context, node NodeInfo, topic string, channel string) error
 
 	// LookupNodes must return a list of of all nodes registered on the engine.
 	LookupNodes(ctx context.Context) ([]NodeInfo, error)
@@ -108,6 +84,38 @@ type Engine interface {
 	// CheckHealth is called by nsqlookup servers to evaluate the health of the
 	// engine.
 	CheckHealth(ctx context.Context) error
+}
+
+// The Node interface is used to represent a single node registered within a
+// nsqlookup engine.
+type Node interface {
+	// Info should return the info given to RegisterNode when the node was
+	// created.
+	Info() NodeInfo
+
+	// Ping is called by nsqlookup servers when a registered node sends a
+	// ping command to inform that it is still alive.
+	Ping(ctx context.Context) error
+
+	// Unregister is called by nsqlookup servers when a node that had
+	// previously registered is going away.
+	Unregister(ctx context.Context) error
+
+	// RegisterTopic is called by nsqlookup servers when topic is being
+	// registered on node.
+	RegisterTopic(ctx context.Context, topic string) error
+
+	// UnregisterTopic is called by nsqlookup servers when topic is being
+	// unregistered from node.
+	UnregisterTopic(ctx context.Context, topic string) error
+
+	// RegisterChannel is called by nsqlookup servers when channel from topic is
+	// being registered on node.
+	RegisterChannel(ctx context.Context, topic string, channel string) error
+
+	// UnregisterChannel is called by nsqlookup servers when channel from topic
+	// is being unregistered from node.
+	UnregisterChannel(ctx context.Context, topic string, channel string) error
 }
 
 type byNode []NodeInfo

--- a/nsqlookup/engine.go
+++ b/nsqlookup/engine.go
@@ -32,6 +32,9 @@ type NodeInfo struct {
 
 // String returns a human-readable representation of the node info.
 func (info NodeInfo) String() string {
+	if len(info.Hostname) != 0 {
+		return info.Hostname
+	}
 	return httpBroadcastAddress(info)
 }
 

--- a/nsqlookup/handler.go
+++ b/nsqlookup/handler.go
@@ -484,7 +484,8 @@ func (h TCPHandler) ServeConn(ctx context.Context, conn net.Conn) {
 
 	defer func() {
 		if node != nil {
-			node.Unregister(engineContext(ctx))
+			err := node.Unregister(engineContext(ctx))
+			log.Printf("UNREGISTER node = %s, err = %s", node, err)
 		}
 	}()
 	defer close(resChan)

--- a/nsqlookup/handler.go
+++ b/nsqlookup/handler.go
@@ -433,7 +433,6 @@ type TCPHandler struct {
 func (h TCPHandler) ServeConn(ctx context.Context, conn net.Conn) {
 	const bufSize = 2048
 
-	var node NodeInfo
 	var r = bufio.NewReaderSize(conn, bufSize)
 	var w = bufio.NewWriterSize(conn, bufSize)
 
@@ -458,12 +457,6 @@ func (h TCPHandler) ServeConn(ctx context.Context, conn net.Conn) {
 		return ectx
 	}
 
-	defer func() {
-		if node != (NodeInfo{}) {
-			h.Engine.UnregisterNode(engineContext(ctx), node)
-		}
-	}()
-
 	host, port, _ := net.SplitHostPort(conn.LocalAddr().String())
 
 	if h.Info.TcpPort == 0 {
@@ -483,11 +476,17 @@ func (h TCPHandler) ServeConn(ctx context.Context, conn net.Conn) {
 		h.Info.Version = info.Version
 	}
 
+	var node Node
 	var cmdChan = make(chan Command)
 	var resChan = make(chan Response)
 	var errChan = make(chan error, 2)
 	var doneChan = ctx.Done()
 
+	defer func() {
+		if node != nil {
+			node.Unregister(engineContext(ctx))
+		}
+	}()
 	defer close(resChan)
 
 	go h.readLoop(ctx, conn, r, cmdChan, errChan)
@@ -543,8 +542,8 @@ func (h TCPHandler) ServeConn(ctx context.Context, conn net.Conn) {
 	}
 }
 
-func (h TCPHandler) identify(ctx context.Context, node NodeInfo, info NodeInfo, conn net.Conn) (id NodeInfo, res RawResponse, err error) {
-	if node != (NodeInfo{}) {
+func (h TCPHandler) identify(ctx context.Context, node Node, info NodeInfo, conn net.Conn) (id Node, res RawResponse, err error) {
+	if node != nil {
 		id, err = node, errCannotIdentifyAgain
 		return
 	}
@@ -554,54 +553,54 @@ func (h TCPHandler) identify(ctx context.Context, node NodeInfo, info NodeInfo, 
 	}
 
 	b, _ := json.Marshal(h.Info)
-	id, res = info, RawResponse(b)
-	err = h.Engine.RegisterNode(ctx, info)
+	res = RawResponse(b)
+	id, err = h.Engine.RegisterNode(ctx, info)
 
-	log.Printf("IDENTIFY node = %v, err = %v", info, err)
+	log.Printf("IDENTIFY node = %s, err = %v", info, err)
 	return
 }
 
-func (h TCPHandler) ping(ctx context.Context, node NodeInfo) (res OK, err error) {
-	if node != (NodeInfo{}) { // ping may arrive before identify
-		err = h.Engine.PingNode(ctx, node)
-		log.Printf("PING node = %v, err = %v", node, err)
+func (h TCPHandler) ping(ctx context.Context, node Node) (res OK, err error) {
+	if node != nil { // ping may arrive before identify
+		err = node.Ping(ctx)
+		log.Printf("PING node = %s, err = %v", node, err)
 	}
 	return
 }
 
-func (h TCPHandler) register(ctx context.Context, node NodeInfo, topic string, channel string) (res OK, err error) {
-	if node == (NodeInfo{}) {
+func (h TCPHandler) register(ctx context.Context, node Node, topic string, channel string) (res OK, err error) {
+	if node == nil {
 		err = errClientMustIdentify
 		return
 	}
 
 	switch {
 	case len(channel) != 0:
-		err = h.Engine.RegisterChannel(ctx, node, topic, channel)
+		err = node.RegisterChannel(ctx, topic, channel)
 
 	case len(topic) != 0:
-		err = h.Engine.RegisterTopic(ctx, node, topic)
+		err = node.RegisterTopic(ctx, topic)
 
 	default:
 		err = makeErrBadTopic("missing topic name")
 	}
 
-	log.Printf("REGISTER node = %v, err = %v", node, err)
+	log.Printf("REGISTER node = %s, topic = %s, channel = %s, err = %v", node, topic, channel, err)
 	return
 }
 
-func (h TCPHandler) unregister(ctx context.Context, node NodeInfo, topic string, channel string) (id NodeInfo, res OK, err error) {
-	if node == (NodeInfo{}) {
+func (h TCPHandler) unregister(ctx context.Context, node Node, topic string, channel string) (id Node, res OK, err error) {
+	if node == nil {
 		err = errClientMustIdentify
 		return
 	}
 
 	switch {
 	case len(channel) != 0:
-		err = h.Engine.UnregisterChannel(ctx, node, topic, channel)
+		err = node.UnregisterChannel(ctx, topic, channel)
 
 	case len(topic) != 0:
-		err = h.Engine.UnregisterTopic(ctx, node, topic)
+		err = node.UnregisterTopic(ctx, topic)
 
 	default:
 		err = makeErrBadTopic("missing topic name")
@@ -611,7 +610,7 @@ func (h TCPHandler) unregister(ctx context.Context, node NodeInfo, topic string,
 		id = node
 	}
 
-	log.Printf("UNREGISTER node = %v, err = %v", node, err)
+	log.Printf("UNREGISTER node = %s, topic = %s, channel = %s, err = %v", node, topic, channel, err)
 	return
 }
 
@@ -703,4 +702,5 @@ var (
 	errClientMustIdentify  = errors.New("client must identify")
 	errCannotIdentifyAgain = errors.New("cannot identify again")
 	errMissingNode         = errors.New("the node doesn't exist")
+	errExpiredNode         = errors.New("the node has expired")
 )


### PR DESCRIPTION
Hey guys,

I was tracking down a race condition that caused nodes to be deregistered and I had to refactor the code a little to get it fixed.

My understanding of the program was that the consul engine was keeping the sessions created by the registered nodes in a map, then removing them when the clients went away.
But that meant that if a nsqd node had opened two connections, when the first one went away it would also invalidate the other one.

The change here gets rid of this global state and instead the engine creates a new node instance per TCP connection, so it's not possible for one connection to overwrite the session of another.

I've tested it on stage and I'm not seeing nodes getting randomly deregistered anymore.
=> https://nsq.segment.build/nodes

Please take a look and let me know if anything should be changed.


PS: moral of the story, global state is B.A.D