### PR TITLE
Filter healthy host

### DIFF
--- a/nsqlookup/resolver.go
+++ b/nsqlookup/resolver.go
@@ -140,7 +140,7 @@ func (r *ConsulResolver) Resolve(ctx context.Context) (list []string, err error)
 
 	err = r.getConsul(ctx, fmt.Sprintf("v1/health/checks/%s?passing", service), &checksResults)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	// get list of nodes for service
@@ -153,7 +153,7 @@ func (r *ConsulResolver) Resolve(ctx context.Context) (list []string, err error)
 
 	err = r.getConsul(ctx, fmt.Sprintf("v1/catalog/service/%s", service), &serviceResults)
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	list = make([]string, 0, len(checksResults))

--- a/nsqlookup/resolver_test.go
+++ b/nsqlookup/resolver_test.go
@@ -109,27 +109,46 @@ func TestResolveCached(t *testing.T) {
 
 func TestResolveConsul(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		if req.URL.Path != "/v1/catalog/service/nsqlookupd" {
+		if req.URL.Path == "/v1/catalog/service/nsqlookupd" {
+			json.NewEncoder(res).Encode([]struct {
+				Node           string
+				ServiceAddress string
+				ServicePort    int
+			}{
+				{
+					Node:           "A",
+					ServiceAddress: "127.0.0.1",
+					ServicePort:    4242,
+				},
+				{
+					Node:           "B",
+					ServiceAddress: "192.168.0.1",
+					ServicePort:    4161,
+				},
+				{
+					Node:           "C",
+					ServiceAddress: "192.168.0.2",
+					ServicePort:    4161,
+				},
+			})
+		} else if req.URL.Path == "/v1/health/checks/nsqlookupd" {
+			json.NewEncoder(res).Encode([]struct {
+				Node string
+			}{
+				{
+					Node: "A",
+				},
+				{
+					Node: "B",
+				},
+				{
+					Node: "C",
+				},
+			})
+		} else {
 			t.Error("bad URL path:", req.URL.Path)
 		}
 		res.Header().Set("Content-Type", "application/json; charset=utf-8")
-		json.NewEncoder(res).Encode([]struct {
-			ServiceAddress string
-			ServicePort    int
-		}{
-			{
-				ServiceAddress: "127.0.0.1",
-				ServicePort:    4242,
-			},
-			{
-				ServiceAddress: "192.168.0.1",
-				ServicePort:    4161,
-			},
-			{
-				ServiceAddress: "192.168.0.2",
-				ServicePort:    4161,
-			},
-		})
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
To avoid issues during tasks maintenance, we need to filter for healthy hosts.

Using /v1/health/checks/nsqlookupd to get the list of current healthy hosts.