### PR TITLE
identify: add MsgTimeout

### DIFF
--- a/identify.go
+++ b/identify.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -22,12 +23,17 @@ type Identify struct {
 	// UserAgent represents the type of the client, by default it is set to
 	// nsq.DefaultUserAgent.
 	UserAgent string
+
+	// Configure the server-side message timeout
+	// for messages delivered to this client.
+	MsgTimeout time.Duration
 }
 
 type identifyBody struct {
-	ClientID  string `json:"client_id,omitempty"`
-	Hostname  string `json:"hostname,omitempty"`
-	UserAgent string `json:"user_agent,omitempty"`
+	ClientID   string `json:"client_id,omitempty"`
+	Hostname   string `json:"hostname,omitempty"`
+	UserAgent  string `json:"user_agent,omitempty"`
+	MsgTimeout int64  `json:"msg_timeout,omitempty"`
 }
 
 // Name returns the name of the command in order to satisfy the Command
@@ -42,9 +48,10 @@ func (c Identify) Write(w *bufio.Writer) (err error) {
 	var data []byte
 
 	if data, err = json.Marshal(identifyBody{
-		ClientID:  c.ClientID,
-		Hostname:  c.Hostname,
-		UserAgent: c.UserAgent,
+		ClientID:   c.ClientID,
+		Hostname:   c.Hostname,
+		UserAgent:  c.UserAgent,
+		MsgTimeout: int64(c.MsgTimeout / time.Millisecond),
 	}); err != nil {
 		return
 	}
@@ -75,9 +82,10 @@ func readIdentify(r *bufio.Reader) (cmd Identify, err error) {
 	}
 
 	cmd = Identify{
-		ClientID:  body.ClientID,
-		Hostname:  body.Hostname,
-		UserAgent: body.UserAgent,
+		ClientID:   body.ClientID,
+		Hostname:   body.Hostname,
+		UserAgent:  body.UserAgent,
+		MsgTimeout: time.Duration(body.MsgTimeout) * time.Millisecond,
 	}
 	return
 }

--- a/identify_test.go
+++ b/identify_test.go
@@ -1,11 +1,21 @@
 package nsq
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestIdentify(t *testing.T) {
 	testCommand(t, "IDENTIFY", Identify{
 		ClientID:  "0123456789",
 		Hostname:  "localhost",
 		UserAgent: "nsq-go/test",
+	})
+
+	testCommand(t, "IDENTIFY", Identify{
+		ClientID:   "0123456789",
+		Hostname:   "localhost",
+		UserAgent:  "nsq-go/test",
+		MsgTimeout: time.Second * 5,
 	})
 }


### PR DESCRIPTION
This PR will let clients configure their own msg_timeout:

```
c, err := nsq.StartConsumer(nsq.ConsumerConfig{
  Identify: nsq.Identify{MsgTimeout: time.Second * 5},
})
```

If `MsgTimeout` is not passed, the behavior should be the same.