### PR TITLE
feat(consumer): add ability to start consuming sometime after init

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -83,8 +83,7 @@ func (c *ConsumerConfig) defaults() {
 
 // NewConsumer configures a new consumer instance.
 func NewConsumer(config ConsumerConfig) (c *Consumer, err error) {
-	if configError := config.validate(); configError != nil {
-		err = configError
+	if err = config.validate(); err != nil {
 		return
 	}
 


### PR DESCRIPTION
This PR adds `NewConsumer()` and `NewProducer()` which will create a consumer/producer that hasn't started consuming messages yet. To complement this, this adds a `Consumer.Start()` and `Producer.Start()` to begin consumption/production on-demand. This should be fully backwards-compatible.

My use-case is that I typically use `main` to organize my config and initialize any API clients. I prefer to start performing actual work inside an internal worker module, which this allows me to do by configuring my nsq consumer (and/or producer) in `main` and then delegating any startup to `worker` which may need to prepare other connections in a different order.