### PR TITLE
feat(message): add factory for use in tests

### DIFF
--- a/message.go
+++ b/message.go
@@ -62,6 +62,20 @@ type Message struct {
 	cmdChan chan<- Command
 }
 
+// NewMessage is a helper for creating Message instances directly. A common
+// use-case is for writing tests, generally you won't use this directly.
+//
+// If you do use this, the Command channel is used internally to communicate
+// message commands, such as "Finish" or "Requeue". When using this for testing,
+// you can make a channel and inspect any message sent along it for assertions.
+func NewMessage(id MessageID, body []byte, cmdChan chan<- Command) *Message {
+	return &Message{
+		ID:      id,
+		Body:    body,
+		cmdChan: cmdChan,
+	}
+}
+
 // Finish must be called on every message received from a consumer to let the
 // NSQ server know that the message was successfully processed.
 //


### PR DESCRIPTION
This adds a factory method for creating ad-hoc `Message` instances. In particular, this is necessary because `cmdChan` is private. This allows writing tests that accept a `Message` where you can assert that the expected `Command` is sent along the channel. (also, calling `Finish` or `Requeue` an message w/o this channel will panic)