### PR TITLE
Changed Consumer.stop() to be blocking

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -143,6 +143,7 @@ func (c *Consumer) Messages() <-chan Message {
 
 func (c *Consumer) stop() {
 	close(c.done)
+	c.join.Wait()
 }
 
 func (c *Consumer) run() {
@@ -163,7 +164,6 @@ func (c *Consumer) run() {
 
 		case <-c.done:
 			c.close()
-			c.join.Wait()
 			return
 		}
 	}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -90,6 +90,10 @@ func TestRequeue(t *testing.T) {
 	}
 	defer c.DeleteTopic("test-requeue")
 
+	// Allow some time for the nsqd nodes to inform nsqlookupd that they host
+	// a specific topic.
+	time.Sleep(100 * time.Millisecond)
+
 	consumer, _ := StartConsumer(ConsumerConfig{
 		Topic:   "test-requeue",
 		Channel: "channel",

--- a/message_test.go
+++ b/message_test.go
@@ -15,7 +15,7 @@ func TestMessage(t *testing.T) {
 			ID:        42,
 			Attempts:  3,
 			Body:      []byte("Hello World!"),
-			Timestamp: time.Now(),
+			Timestamp: time.Now().Round(time.Nanosecond),
 		},
 	} {
 		t.Run(m.ID.String(), func(t *testing.T) {


### PR DESCRIPTION
`Consumer.Stop()` is non-blocking, so it doesn't wait for all the goroutines to exit before returning. There is a small chance that `runConn()` is left running and receiving messages from NSQD after `Consumer.Stop()` returns.

In the `schema-service` tests, some messages were consumed by the goroutine in an old `Consumer` in this way and that left the new Consumer with no message. This caused the tests to fail intermittently. 