### PR TITLE
Support the more flattened HTTP response, supporting nsq v1+

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -52,22 +52,18 @@ func (c *LookupClient) Lookup(topic string) (result LookupResult, err error) {
 	producers := make(map[producerInfoKey]ProducerInfo)
 
 	for _, r := range retList {
-		v := struct {
-			StatusCode int          `json:"status_code"`
-			StatusTxt  string       `json:"status_txt"`
-			Data       LookupResult `json:"data"`
-		}{}
+		var lookupResult LookupResult
 
-		if e := json.Unmarshal(r, &v); e != nil {
+		if e := json.Unmarshal(r, &lookupResult); e != nil {
 			err = appendError(err, e)
 			continue
 		}
 
-		for _, c := range v.Data.Channels {
+		for _, c := range lookupResult.Channels {
 			channels[c] = true
 		}
 
-		for _, p := range v.Data.Producers {
+		for _, p := range lookupResult.Producers {
 			producers[producerInfoKey{
 				BroadcastAddress: p.BroadcastAddress,
 				Hostname:         p.Hostname,


### PR DESCRIPTION
I noticed in `handler.go`:

```
	v1 := req.Header.Get("Accept") == "application/vnd.nsq; version=1.0"

	if !v1 {
		value = struct {
			StatusCode int         `json:"status_code"`
			StatusText string      `json:"status_txt"`
			Data       interface{} `json:"data"`
		}{
			StatusCode: status,
			StatusText: text,
			Data:       value,
		}
	}
```

We could also do something similar here to support both versions.. a bit more refactoring would need to happen through, to bubble up the headers alongside the `ret`, or the `ret` could be a channel of more structured objects, like the `LookupResult` itself.. 