### PR TITLE
Deprecate segment/nsq image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,23 +71,6 @@ jobs:
             go build ./cmd/nsq-to-nsq
             go build ./cmd/nsq-to-http
             go build ./cmd/nsqlookup-proxy
-      - run:
-          name: Publish Docker Image
-          command: |
-            tag=${CIRCLE_TAG:-circleci-$CIRCLE_BUILD_NUM}
-            docker_hub_image=segment/nsq:${tag}
-            ecr_image=528451384384.dkr.ecr.us-west-2.amazonaws.com/nsq:${tag}
-
-            $(aws ecr get-login --no-include-email --region ${AWS_REGION})
-
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker build -t nsq .
-
-            docker tag nsq ${docker_hub_image}
-            docker tag nsq ${ecr_image}
-
-            docker push ${docker_hub_image}
-            docker push ${ecr_image}
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM alpine
-COPY /nsq-to-nsq /usr/local/bin/nsq-to-nsq
-COPY /nsq-to-http /usr/local/bin/nsq-to-http
-COPY /nsqlookup-proxy /usr/local/bin/nsqlookup-proxy

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Motivations
 
 We ran into production issues with the standard nsq-go package where our workers
 would enter deadlock situations where they would stop consuming messages and
-just hang in endless termination loops.  
+just hang in endless termination loops.
 After digging through the code and trying to figure out how to address the
 problem it became clear that a rewrite was going to be faster than dealing with
 the amount of state synchronization that was done in nsq-go (multiple mutexes,
@@ -80,12 +80,3 @@ func main() {
     producer.Stop()
 }
 ```
-
-segment/nsq
------------
-
-The [segment/nsq](https://hub.docker.com/r/segment/nsq/tags) docker image packages
-the tools within this repository:
-- **nsq-to-nsq** is similar to the standard nsq_to_nsq tool but supports rate limiting.
-- **nsqlookup-proxy** is a proxy for nsqlookupd, it aggregates the results from querying
-multiple nsqlookupd servers and exposes them under a single endpoint.


### PR DESCRIPTION
## Description
This change updates `nsq-go` to deprecate the `segment/nsq` image that we were previously publishing. From what I can find, there isn't any significant usage of it either inside segment or outside, and there are reasonable alternatives in most cases.