### PR TITLE
Revert "add dockerignore file"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-.git
-.circleci
-.buildkite
-.github


### PR DESCRIPTION
Reverts segmentio/nsq-go#41

This repo doesn't have a Dockerfile, so there is nothing to ignore. See https://github.com/segmentio/nsq-go/pull/42.