### PR TITLE
Remove dependency on github.com/segmentio/services

### DIFF
--- a/cmd/nsqlookup-proxy/main.go
+++ b/cmd/nsqlookup-proxy/main.go
@@ -14,7 +14,6 @@ import (
 	_ "github.com/segmentio/events/text"
 	nsq "github.com/segmentio/nsq-go"
 	"github.com/segmentio/nsq-go/nsqlookup"
-	"github.com/segmentio/services"
 )
 
 func main() {
@@ -54,7 +53,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	var registry services.Registry
+	var registry nsqlookup.Registry
 	protocol, address, nsqlookupd := splitAddressService(args[0])
 
 	switch protocol {
@@ -97,7 +96,7 @@ func main() {
 		Topology:   topology,
 		Nsqlookupd: nsqlookupd,
 
-		Registry: &services.Cache{
+		Registry: &nsqlookup.Cache{
 			Registry: registry,
 			MinTTL:   config.CacheTimeout,
 			MaxTTL:   config.CacheTimeout,

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/segmentio/nsq-go
 
+go 1.11
+
 require (
 	github.com/pkg/errors v0.8.0
 	github.com/segmentio/conf v1.0.0
 	github.com/segmentio/events v2.1.0+incompatible
 	github.com/segmentio/go-snakecase v1.0.0 // indirect
 	github.com/segmentio/objconv v1.0.1 // indirect
-	github.com/segmentio/services v0.0.0-20180216231230-ef69a333c883
 	github.com/segmentio/timers v0.0.0-20180605162245-8ad1428b010e
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/mold.v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/segmentio/go-snakecase v1.0.0 h1:FSeHpP0sBL3O+MCpxvQZrS5a51WAki6gposZ
 github.com/segmentio/go-snakecase v1.0.0/go.mod h1:jk1miR5MS7Na32PZUykG89Arm+1BUSYhuGR6b7+hJto=
 github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=
 github.com/segmentio/objconv v1.0.1/go.mod h1:auayaH5k3137Cl4SoXTgrzQcuQDmvuVtZgS0fb1Ahys=
-github.com/segmentio/services v0.0.0-20180216231230-ef69a333c883 h1:JqbzvA4jdc5j0Juqr16hvQqtzP6NeejMfQiKW2IH2Ww=
-github.com/segmentio/services v0.0.0-20180216231230-ef69a333c883/go.mod h1:FC5k6yQaY7PKSOlPxJTaKMj/Qm/P+IBBGC/GKXPF28w=
 github.com/segmentio/timers v0.0.0-20180605162245-8ad1428b010e h1:GNlZqttb0RQTUYTYnSwAMyqgHzYouBGVImRJp8Y43Hg=
 github.com/segmentio/timers v0.0.0-20180605162245-8ad1428b010e/go.mod h1:/6SKE4F6LzTh32hPOJs0KRJ7MHHWpTZ7wb4PxdjgzaQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/nsqlookup/cache.go
+++ b/nsqlookup/cache.go
@@ -1,0 +1,321 @@
+package nsqlookup
+
+import (
+	"container/list"
+	"context"
+	"math"
+	"math/rand"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+// Cache provides the implementation of an in-memory caching layer for a service
+// registry.
+//
+// When used as a resolver, the cache uses a load balancing strategy to return a
+// different address on every call to Resolve.
+//
+// Cache implements both the Registry and Resolver interfaces, which means they
+// are safe to use concurrently from multiple goroutines.
+//
+// Cache values must not be copied after being used.
+type Cache struct {
+	// Base registry to cache services for. This field must not be nil.
+	Registry Registry
+
+	// Minimum and maximum TTLs applied to cache entries.
+	MinTTL time.Duration
+	MaxTTL time.Duration
+
+	// Maximum size of the cache (in bytes). Defaults to 1 MB.
+	MaxBytes int64
+
+	// concurrent LRU cache
+	mutex sync.Mutex
+	items map[cacheKey]*list.Element
+	queue list.List
+
+	// stats
+	bytes     int64
+	size      int64
+	hits      int64
+	misses    int64
+	evictions int64
+}
+
+// CacheStats exposes internal statistics on service cache utilization.
+type CacheStats struct {
+	Bytes     int64 `metric:"services.cache.bytes"     type:"gauge"`
+	Size      int64 `metric:"services.cache.size"      type:"gauge"`
+	Hits      int64 `metric:"services.cache.hits"      type:"counter"`
+	Misses    int64 `metric:"services.cache.misses"    type:"counter"`
+	Evictions int64 `metric:"services.cache.evictions" type:"counter"`
+}
+
+// Stats takes a snapshot of the current utilization statistics of the cache.
+//
+// Note that because cache is safe to use concurrently from multiple goroutines,
+// cache statistics are eventually consistent and a snapshot may not reflect the
+// effect of concurrent utilization of the cache.
+func (c *Cache) Stats() CacheStats {
+	return CacheStats{
+		Bytes:     atomic.LoadInt64(&c.bytes),
+		Size:      atomic.LoadInt64(&c.size),
+		Hits:      atomic.LoadInt64(&c.hits),
+		Misses:    atomic.LoadInt64(&c.misses),
+		Evictions: atomic.LoadInt64(&c.evictions),
+	}
+}
+
+// Resolve satisfies the Resolver interface.
+func (c *Cache) Resolve(ctx context.Context, name string) (string, error) {
+	index, addrs, _, err := c.lookup(ctx, name)
+	if err != nil {
+		return "", err
+	}
+
+	i := atomic.AddUint64(index, +1)
+	n := uint64(len(addrs))
+
+	if n == 0 {
+		return "", &cacheError{name: name}
+	}
+
+	return addrs[i%n], nil
+}
+
+// Lookup satisfies the Registry interface.
+func (c *Cache) Lookup(ctx context.Context, name string, tags ...string) ([]string, time.Duration, error) {
+	_, addrs, deadline, err := c.lookup(ctx, name, tags...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	now := time.Now()
+	ttl := time.Duration(0)
+
+	if !now.After(deadline) {
+		ttl = deadline.Sub(now)
+	}
+
+	return copyStrings(addrs), ttl, err
+}
+
+func (c *Cache) lookup(ctx context.Context, name string, tags ...string) (*uint64, []string, time.Time, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, time.Time{}, err
+	}
+
+	tags = sortedStrings(tags)
+	key := makeCacheKey(name, tags)
+
+	for {
+		c.mutex.Lock()
+		elem, hit := c.items[key]
+		if hit {
+			c.queue.MoveToFront(elem)
+		} else {
+			elem = c.queue.PushFront(newCacheItem(key, tags))
+			if c.items == nil {
+				c.items = map[cacheKey]*list.Element{key: elem}
+			} else {
+				c.items[key] = elem
+			}
+		}
+		c.mutex.Unlock()
+
+		item := elem.Value.(*cacheItem)
+		if !hit {
+			go item.lookup(c.Registry, c.minTTL(), c.maxTTL())
+		}
+
+		select {
+		case <-item.ready:
+		case <-ctx.Done():
+			return nil, nil, time.Time{}, ctx.Err()
+		}
+
+		if time.Now().After(item.ttl) {
+			evict := false
+			c.mutex.Lock()
+			// Make sure another goroutine did not concurrently remove the
+			// item.
+			if evict = c.items[key] == elem; evict {
+				c.queue.Remove(elem)
+				delete(c.items, key)
+			}
+			c.mutex.Unlock()
+
+			if evict {
+				atomic.AddInt64(&c.bytes, -item.bytes)
+				atomic.AddInt64(&c.size, -1)
+				atomic.AddInt64(&c.evictions, +1)
+				if hit {
+					// In case we had a cache miss, still let the code go
+					// through otherwise we may enture en infinite loop when the
+					// TTL is so low. Basically, this ensures that new items are
+					// always used at least once.
+					continue
+				}
+			}
+		}
+
+		if hit {
+			atomic.AddInt64(&c.hits, +1)
+		} else {
+			atomic.AddInt64(&c.size, +1)
+			atomic.AddInt64(&c.misses, +1)
+
+			bytes := atomic.AddInt64(&c.bytes, +item.bytes)
+			maxBytes := int64(c.maxBytes())
+
+			for bytes > maxBytes {
+				c.mutex.Lock()
+
+				if len(c.items) == 0 {
+					c.mutex.Unlock()
+					break
+				}
+
+				oldestElem := c.queue.Back()
+				oldestItem := oldestElem.Value.(*cacheItem)
+				c.queue.Remove(oldestElem)
+				delete(c.items, oldestItem.key)
+				c.mutex.Unlock()
+
+				bytes = atomic.AddInt64(&c.bytes, -oldestItem.bytes)
+				atomic.AddInt64(&c.size, -1)
+				atomic.AddInt64(&c.evictions, +1)
+			}
+		}
+
+		return &item.index, item.addrs, item.ttl, item.err
+	}
+}
+
+func (c *Cache) maxBytes() int64 {
+	if bytes := c.MaxBytes; bytes > 0 {
+		return int64(bytes)
+	}
+	return 1024 * 1024 // 1 MB
+}
+
+func (c *Cache) minTTL() time.Duration {
+	if ttl := c.MinTTL; ttl > 0 {
+		return ttl
+	}
+	return 0
+}
+
+func (c *Cache) maxTTL() time.Duration {
+	if ttl := c.MaxTTL; ttl > 0 {
+		return ttl
+	}
+	return time.Duration(math.MaxInt64)
+}
+
+type cacheKey struct {
+	name string
+	tags string
+}
+
+func makeCacheKey(name string, tags []string) cacheKey {
+	return cacheKey{
+		name: name,
+		tags: strings.Join(tags, ","),
+	}
+}
+
+type cacheItem struct {
+	index uint64
+	key   cacheKey
+	tags  []string
+	addrs []string
+	bytes int64
+	ttl   time.Time
+	err   error
+	ready chan struct{}
+}
+
+func newCacheItem(key cacheKey, tags []string) *cacheItem {
+	return &cacheItem{
+		key:   key,
+		ready: make(chan struct{}),
+	}
+}
+
+func (item *cacheItem) lookup(r Registry, minTTL, maxTTL time.Duration) {
+	addrs, ttl, err := r.Lookup(context.Background(), item.key.name, item.tags...)
+
+	if ttl < minTTL {
+		ttl = minTTL
+	}
+
+	if ttl > maxTTL {
+		ttl = maxTTL
+	}
+
+	item.bytes = int64(unsafe.Sizeof(*item)) +
+		sizeofStrings(addrs) +
+		sizeofString(item.key.name) +
+		sizeofString(item.key.tags) +
+		sizeofStrings(item.tags)
+
+	item.addrs = shuffledStrings(addrs)
+	item.ttl = time.Now().Add(ttl)
+	item.err = err
+	close(item.ready)
+}
+
+type cacheError struct {
+	name string
+}
+
+func (e *cacheError) Error() string {
+	return e.name + ": no results returned to the cache by the base service registry"
+}
+
+func (e *cacheError) Unreachable() bool {
+	return true
+}
+
+func sortedStrings(s []string) []string {
+	s = copyStrings(s)
+	if len(s) > 1 {
+		sort.Strings(s)
+	}
+	return s
+}
+
+func copyStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	c := make([]string, len(s))
+	copy(c, s)
+	return c
+}
+
+func shuffledStrings(s []string) []string {
+	c := make([]string, len(s))
+	for i, j := range rand.Perm(len(s)) {
+		c[i] = s[j]
+	}
+	return c
+}
+
+func sizeofStrings(s []string) int64 {
+	size := int64(unsafe.Sizeof(s))
+	for i := range s {
+		size += sizeofString(s[i])
+	}
+	return size
+}
+
+func sizeofString(s string) int64 {
+	return int64(unsafe.Sizeof(s)) + int64(len(s))
+}

--- a/nsqlookup/engine.go
+++ b/nsqlookup/engine.go
@@ -228,11 +228,6 @@ func sortedNodes2(n []NodeInfo2) []NodeInfo2 {
 	return n
 }
 
-func sortedStrings(s []string) []string {
-	sort.Strings(s)
-	return s
-}
-
 func httpBroadcastAddress(info NodeInfo) string {
 	return makeBroadcastAddress(info.BroadcastAddress, info.HttpPort)
 }

--- a/nsqlookup/engine_test.go
+++ b/nsqlookup/engine_test.go
@@ -510,8 +510,8 @@ func checkEqualNodes2(t *testing.T, n1 []NodeInfo, n2 []NodeInfo2) {
 }
 
 func checkEqualTopics(t *testing.T, t1 []string, t2 []string) {
-	sortedStrings(t1)
-	sortedStrings(t2)
+	t1 = sortedStrings(t1)
+	t2 = sortedStrings(t2)
 
 	if !reflect.DeepEqual(t1, t2) {
 		t.Logf("<<< %#v", t1)
@@ -521,8 +521,8 @@ func checkEqualTopics(t *testing.T, t1 []string, t2 []string) {
 }
 
 func checkEqualChannels(t *testing.T, c1 []string, c2 []string) {
-	sortedStrings(c1)
-	sortedStrings(c2)
+	c1 = sortedStrings(c1)
+	c2 = sortedStrings(c2)
 
 	if !reflect.DeepEqual(c1, c2) {
 		t.Logf("<<< %#v", c1)

--- a/nsqlookup/resolver.go
+++ b/nsqlookup/resolver.go
@@ -9,11 +9,29 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/segmentio/services"
 )
 
-type Registry = services.Registry
+type Registry interface {
+	// Lookup returns a set of addresses at which services with the given name
+	// can be reached.
+	//
+	// An arbitrary list of tags can be passed to the method to narrow down the
+	// result set to services matching this set of tags. No tags means to do no
+	// filtering.
+	//
+	// The method also returns a TTL representing how long the result is valid
+	// for. A zero TTL means that the caller should not reuse the result.
+	//
+	// The returned list of addresses must not be retained by implementations of
+	// the Registry interface. The caller becomes the owner of the value after
+	// the method returned.
+	//
+	// A non-nil error is returned when the lookup cannot be completed.
+	//
+	// The context can be used to asynchronously cancel the query when it
+	// involves blocking operations.
+	Lookup(ctx context.Context, name string, tags ...string) (addrs []string, ttl time.Duration, err error)
+}
 
 // LocalRegistry is an implementation of a immutable set of services. This type
 // is mostly useful for testing purposes.
@@ -116,6 +134,6 @@ func (r *ConsulRegistry) get(ctx context.Context, endpoint string, result interf
 }
 
 var (
-	_ services.Registry = (LocalRegistry)(nil)
-	_ services.Registry = (*ConsulRegistry)(nil)
+	_ Registry = (LocalRegistry)(nil)
+	_ Registry = (*ConsulRegistry)(nil)
 )


### PR DESCRIPTION
It seems like `github.com/segmentio/services` was deprecated and moved to the boneyard recently, so the tag that we pull in no longer exists and is breaking builds.

This PR copy/pastes the minimal code from `github.com/segmentio/services` in order to break the dependency.