### PR TITLE
Add producer StopWithDrain

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -116,11 +116,32 @@ func (p *Producer) Start() {
 	p.started = true
 }
 
-// Stop gracefully shutsdown the producer, cancelling all inflight requests and
+// StopWithWait gracefully shuts down the producer, allowing all inflight
+// requests to be sent and for all backend connections to be closed. Once those
+// actions are complete, the wait group is signaled.
+//
+// It is safe to call the method, or Stop, multiple times and from multiple
+// goroutines; they will all block until the producer has been completely
+// shutdown. Note, though, that if Stop is called first, a subsequent call to
+// StopWithWait will not allow for inflight requests to be sent.
+func (p *Producer) StopWithWait(wg *sync.WaitGroup) {
+	go func() {
+		defer wg.Done()
+
+		p.once.Do(func() {
+			close(p.reqs)
+		})
+		p.join.Wait()
+	}()
+}
+
+// Stop gracefully shuts down the producer, cancelling all inflight requests and
 // waiting for all backend connections to be closed.
 //
-// It is safe to call the method multiple times and from multiple goroutines,
-// they will all block until the producer has been completely shutdown.
+// It is safe to call the method, or StopWithWait, multiple times and from
+// multiple goroutines; they will all block until the producer has been
+// completely shutdown. Note, though, that if StopWithWait is called first, a
+// subsequent call to Stop will not prevent inflight requests from being sent.
 func (p *Producer) Stop() {
 	p.once.Do(p.stop)
 	err := errors.New("publishing to a producer that was already stopped")
@@ -261,7 +282,8 @@ func (p *Producer) run() {
 			}
 
 		case req, ok := <-reqChan:
-			if !ok {
+			if !ok && req.Topic == "" {
+				// exit if reqChan is closed and there are no more requests to process
 				return
 			}
 

--- a/producer.go
+++ b/producer.go
@@ -116,23 +116,18 @@ func (p *Producer) Start() {
 	p.started = true
 }
 
-// StopWithWait gracefully shuts down the producer, allowing all inflight
-// requests to be sent and for all backend connections to be closed. Once those
-// actions are complete, the wait group is signaled.
+// StopWithDrain gracefully shuts down the producer, allowing all inflight
+// requests to be sent and for all backend connections to be closed.
 //
 // It is safe to call the method, or Stop, multiple times and from multiple
 // goroutines; they will all block until the producer has been completely
 // shutdown. Note, though, that if Stop is called first, a subsequent call to
-// StopWithWait will not allow for inflight requests to be sent.
-func (p *Producer) StopWithWait(wg *sync.WaitGroup) {
-	go func() {
-		defer wg.Done()
-
-		p.once.Do(func() {
-			close(p.reqs)
-		})
-		p.join.Wait()
-	}()
+// StopWithWait will not allow inflight requests to be sent.
+func (p *Producer) StopWithDrain() {
+	p.once.Do(func() {
+		close(p.reqs)
+	})
+	p.join.Wait()
 }
 
 // Stop gracefully shuts down the producer, cancelling all inflight requests and
@@ -140,7 +135,7 @@ func (p *Producer) StopWithWait(wg *sync.WaitGroup) {
 //
 // It is safe to call the method, or StopWithWait, multiple times and from
 // multiple goroutines; they will all block until the producer has been
-// completely shutdown. Note, though, that if StopWithWait is called first, a
+// completely shutdown. Note, though, that if StopWithDrain is called first, a
 // subsequent call to Stop will not prevent inflight requests from being sent.
 func (p *Producer) Stop() {
 	p.once.Do(p.stop)


### PR DESCRIPTION
The new producer StopWithDrain method stops a producer, but allows
producer requests that have been queued from Publish / PublishTo calls
to be sent to nsq. No new messages may be published after the method
shuts down the internal requests queue.

Because of the `select` ordering for request handling in the producer,
this new method cannot guarantee processing of responses that return
from nsq for messages that are drained.