### PR TITLE
Make connection errors for producer optional

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,8 @@
 
-v? / ?
+v1.2.5 / ?
 ======
 
+  * Optionally return connection errors for producer requests
   * Add producer StopWithDrain
 
 v1.2.4 / 2020-07-13

--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ func main() {
     producer.Stop()
 }
 ```
+
+Testing
+-------
+
+Unit tests expect Consul and a set of NSQ daemons to be running. Start them
+using Docker Compose, and then run unit tests.
+
+```shell
+docker-compose up -d
+go test -v -race ./...
+docker-compose down
+```


### PR DESCRIPTION
The new ability for producers to return connection errors introduced in
PR #46 is made optional. The default behavior for producers reverts to
what it was: blocking the submission of messages on connection failure.
When the new `FailOnConnErr` flag in `ProducerConfig` is set to `true`,
then the new error support is active instead.
