### PR TITLE
[EDGE-137] added drainAndJoinAwait for consumer stop to handle deadlock scenario related to NSQ message timeout

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -161,7 +161,7 @@ func TestDrainAndRequeueOnStop(t *testing.T) {
 		DialTimeout:  time.Second * 60,
 		ReadTimeout:  time.Second * 60,
 		WriteTimeout: time.Second * 60,
-		MaxInFlight: 10,
+		MaxInFlight:  10,
 	})
 
 	if err != nil {
@@ -203,7 +203,7 @@ func TestDrainAndRequeueOnStop(t *testing.T) {
 		DialTimeout:  time.Second * 60,
 		ReadTimeout:  time.Second * 60,
 		WriteTimeout: time.Second * 60,
-		MaxInFlight: 100,
+		MaxInFlight:  100,
 	})
 
 	deadline = time.NewTimer(10 * time.Second)
@@ -233,5 +233,116 @@ func TestDrainAndRequeueOnStop(t *testing.T) {
 	for msg := range consumer2.Messages() {
 		t.Error("unexpected message:", msg)
 		msg.Finish()
+	}
+}
+
+func TestDrainAndRequeueOnStopWithMessageTimeout(t *testing.T) {
+	TopicName := "test-stop-requeue-message-timeout"
+	mumberMessages := 25
+	p, _ := NewProducer(ProducerConfig{
+		Topic:        TopicName,
+		Address:      "localhost:4150",
+		DialTimeout:  time.Second * 60,
+		ReadTimeout:  time.Second * 60,
+		WriteTimeout: time.Second * 60,
+	})
+	sentMessages := make(map[string]bool)
+	p.Start()
+	for i := 0; i < mumberMessages; i++ {
+		msg := strconv.Itoa(i)
+		if err := p.Publish([]byte(msg)); err != nil {
+			t.Error(err)
+			return
+		}
+		sentMessages[msg] = true
+	}
+
+	consumer, err := NewConsumer(ConsumerConfig{
+		Topic:        TopicName,
+		Channel:      "foo",
+		Address:      "localhost:4150",
+		DialTimeout:  time.Second * 60,
+		ReadTimeout:  time.Second * 60,
+		WriteTimeout: time.Second * 60,
+		MaxInFlight:  5,
+		Identify:     Identify{MessageTimeout: time.Second * 2},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	consumer.Start()
+
+	deadline := time.NewTimer(10 * time.Second)
+	defer deadline.Stop()
+
+	// Consume 5 messages do not ack on them
+	// to incur a re-queue on remaining in flight
+	msgNum := 0
+	for msgNum < 5 {
+		select {
+		case msg := <-consumer.Messages():
+			fmt.Printf("start handling message %s\n", string(msg.Body))
+			msgNum++
+		case <-deadline.C:
+			t.Error("timeout")
+			return
+		}
+	}
+	fmt.Printf("Allow some time for the nsqd to timeout received messages")
+	// Allow some time for the nsqd to timeout received messages and send 10+ more messages
+	// to client to deadlock runConn
+	time.Sleep(6 * time.Second)
+	// At this point runConn should have deadlock when Stop is executing
+	consumer.Stop()
+
+	//Make sure the channel gets closed at some point.
+	for msg := range consumer.Messages() {
+		t.Error("unexpected message:", msg)
+		msg.Finish()
+	}
+
+	consumer2, _ := NewConsumer(ConsumerConfig{
+		Topic:        TopicName,
+		Channel:      "foo",
+		Address:      "localhost:4150",
+		DialTimeout:  time.Second * 60,
+		ReadTimeout:  time.Second * 60,
+		WriteTimeout: time.Second * 60,
+		MaxInFlight:  100,
+	})
+
+	deadline = time.NewTimer(10 * time.Second)
+	defer deadline.Stop()
+
+	consumer2.Start()
+
+	msgNum = 0
+	for msgNum < mumberMessages {
+		select {
+		case msg := <-consumer2.Messages():
+			fmt.Printf("handling message %s\n", string(msg.Body))
+			msg.Finish()
+			msgNum++
+			delete(sentMessages, string(msg.Body))
+		case <-deadline.C:
+			t.Error("timeout")
+			return
+		}
+	}
+
+	consumer2.Stop()
+
+	//Make sure the channel gets closed at some point.
+	for msg := range consumer2.Messages() {
+		t.Error("unexpected message:", msg)
+		msg.Finish()
+	}
+	// Make sure we received all sent messages
+	if len(sentMessages) > 0 {
+		for msg := range sentMessages {
+			t.Error("Client did not receive message: ", msg)
+		}
 	}
 }


### PR DESCRIPTION
The consumer `Stop` could be end up into deadlock  at `runConn` routine,  when we are shutdown `Consumer.run()`  in  <-c.done case.

It is could happens when consumer received the number of messages equal or more maxInFlight and we did not **ack** any of those messages back to NSQ within **message-time** period (default 60 seconds),
The NSQ will automatically start re-queue them and send next messages from queue to consumer.
But at this point the messages channel will be in deadlock scenario because it is already full and it deadlock `runConn` routine. 

Changes:

* Added drainAndJoinAwait for consumer stop to handle deadlock scenario related to NSQ message timeout
* Added test for deadlock case