### PR TITLE
nsq: ensure tests are using ipv4

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -283,14 +283,14 @@ func TestDrainAndRequeueOnStopWithMessageTimeout(t *testing.T) {
 	for msgNum < 5 {
 		select {
 		case msg := <-consumer.Messages():
-			fmt.Printf("start handling message %s\n", string(msg.Body))
+			fmt.Printf("consumer 1: handling message %s\n", string(msg.Body))
 			msgNum++
 		case <-deadline.C:
 			t.Error("timeout")
 			return
 		}
 	}
-	fmt.Printf("Allow some time for the nsqd to timeout received messages")
+	fmt.Printf("Allow some time for the nsqd to timeout received messages\n")
 	// Allow some time for the nsqd to timeout received messages and send 10+ more messages
 	// to client to deadlock runConn
 	time.Sleep(6 * time.Second)
@@ -322,7 +322,7 @@ func TestDrainAndRequeueOnStopWithMessageTimeout(t *testing.T) {
 	for msgNum < numberMessages {
 		select {
 		case msg := <-consumer2.Messages():
-			fmt.Printf("handling message %s\n", string(msg.Body))
+			fmt.Printf("consumer 2: handling message %s\n", string(msg.Body))
 			msg.Finish()
 			msgNum++
 			delete(sentMessages, string(msg.Body))

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -82,7 +82,7 @@ func TestConsumer(t *testing.T) {
 }
 
 func TestRequeue(t *testing.T) {
-	c := &Client{Address: "localhost:4151"}
+	c := &Client{Address: "127.0.0.1:4151"}
 
 	if err := c.Publish("test-requeue", []byte("Hello World!")); err != nil {
 		t.Error(err)
@@ -140,7 +140,7 @@ func TestRequeue(t *testing.T) {
 func TestDrainAndRequeueOnStop(t *testing.T) {
 	p, _ := NewProducer(ProducerConfig{
 		Topic:        "test-stop-requeue",
-		Address:      "localhost:4150",
+		Address:      "127.0.0.1:4150",
 		DialTimeout:  time.Second * 60,
 		ReadTimeout:  time.Second * 60,
 		WriteTimeout: time.Second * 60,
@@ -157,7 +157,7 @@ func TestDrainAndRequeueOnStop(t *testing.T) {
 	consumer, err := NewConsumer(ConsumerConfig{
 		Topic:        "test-stop-requeue",
 		Channel:      "foo",
-		Address:      "localhost:4150",
+		Address:      "127.0.0.1:4150",
 		DialTimeout:  time.Second * 60,
 		ReadTimeout:  time.Second * 60,
 		WriteTimeout: time.Second * 60,
@@ -199,7 +199,7 @@ func TestDrainAndRequeueOnStop(t *testing.T) {
 	consumer2, _ := NewConsumer(ConsumerConfig{
 		Topic:        "test-stop-requeue",
 		Channel:      "foo",
-		Address:      "localhost:4150",
+		Address:      "127.0.0.1:4150",
 		DialTimeout:  time.Second * 60,
 		ReadTimeout:  time.Second * 60,
 		WriteTimeout: time.Second * 60,
@@ -241,7 +241,7 @@ func TestDrainAndRequeueOnStopWithMessageTimeout(t *testing.T) {
 	numberMessages := 25
 	p, _ := NewProducer(ProducerConfig{
 		Topic:        TopicName,
-		Address:      "localhost:4150",
+		Address:      "127.0.0.1:4150",
 		DialTimeout:  time.Second * 60,
 		ReadTimeout:  time.Second * 60,
 		WriteTimeout: time.Second * 60,
@@ -260,7 +260,7 @@ func TestDrainAndRequeueOnStopWithMessageTimeout(t *testing.T) {
 	consumer, err := NewConsumer(ConsumerConfig{
 		Topic:        TopicName,
 		Channel:      "foo",
-		Address:      "localhost:4150",
+		Address:      "127.0.0.1:4150",
 		DialTimeout:  time.Second * 60,
 		ReadTimeout:  time.Second * 60,
 		WriteTimeout: time.Second * 60,
@@ -306,7 +306,7 @@ func TestDrainAndRequeueOnStopWithMessageTimeout(t *testing.T) {
 	consumer2, _ := NewConsumer(ConsumerConfig{
 		Topic:        TopicName,
 		Channel:      "foo",
-		Address:      "localhost:4150",
+		Address:      "127.0.0.1:4150",
 		DialTimeout:  time.Second * 60,
 		ReadTimeout:  time.Second * 60,
 		WriteTimeout: time.Second * 60,

--- a/identify_test.go
+++ b/identify_test.go
@@ -8,13 +8,13 @@ import (
 func TestIdentify(t *testing.T) {
 	testCommand(t, "IDENTIFY", Identify{
 		ClientID:  "0123456789",
-		Hostname:  "localhost",
+		Hostname:  "127.0.0.1",
 		UserAgent: "nsq-go/test",
 		// timeout omitted.
 	})
 	testCommand(t, "IDENTIFY", Identify{
 		ClientID:       "0123456789",
-		Hostname:       "localhost",
+		Hostname:       "127.0.0.1",
 		UserAgent:      "nsq-go/test",
 		MessageTimeout: 10 * time.Minute,
 	})

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -7,15 +7,15 @@ import (
 
 var (
 	nsqlookup = []string{
-		"localhost:4161", // nsqlookup-1
-		"localhost:4163", // nsqlookup-2
-		"localhost:4165", // nsqlookup-3
+		"127.0.0.1:4161", // nsqlookup-1
+		"127.0.0.1:4163", // nsqlookup-2
+		"127.0.0.1:4165", // nsqlookup-3
 	}
 
 	nsqd = []string{
-		"localhost:4151", // nsqd-1
-		"localhost:4153", // nsqd-2
-		"localhost:4155", // nsqd-3
+		"127.0.0.1:4151", // nsqd-1
+		"127.0.0.1:4153", // nsqd-2
+		"127.0.0.1:4155", // nsqd-3
 	}
 )
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -17,7 +17,7 @@ func TestProducer(t *testing.T) {
 			c, _ := StartConsumer(ConsumerConfig{
 				Topic:   topic,
 				Channel: "channel",
-				Address: "localhost:4150",
+				Address: "127.0.0.1:4150",
 			})
 			defer c.Stop()
 
@@ -25,7 +25,7 @@ func TestProducer(t *testing.T) {
 			time.Sleep(100 * time.Millisecond)
 
 			p, _ := StartProducer(ProducerConfig{
-				Address:        "localhost:4150",
+				Address:        "127.0.0.1:4150",
 				Topic:          topic,
 				MaxConcurrency: 3,
 			})


### PR DESCRIPTION
I was running into some flakiness running the tests on Mac, which tries to dial ipv6 if you specify "localhost" so try to ensure we are dialing on ipv4. The tests pass now, not sure if it's my change or not, but these seem like reasonable changes to make.