### PR TITLE
all: use "docker compose" not "docker-compose"

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Unit tests expect Consul and a set of NSQ daemons to be running. Start them
 using Docker Compose, and then run unit tests.
 
 ```shell
-docker-compose up -d
+docker compose up -d
 go test -v -race ./...
-docker-compose down
+docker compose down
 ```


### PR DESCRIPTION
As part of the Docker binary this will be updated more often and has better support and newer features than the separate "docker-compose" binary.