### PR TITLE
docker-compose.yml: specify AMD64 platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,35 +7,50 @@ services:
     image: hashicorp/consul:latest
     command: agent -server -dev -log-level debug -client 0.0.0.0
     ports:
-      - 8500:8500
+    - 8500:8500
 
+    # If you are on arm64 and experiencing issues with the tests (hangs,
+    # connection reset) then try the following in order:
+
+    # - stopping and removing all downloaded container images
+    # - ensuring you have the latest Docker Desktop version
+    # - factory reset your Docker Desktop settings
+
+    # If you are still running into issues please post in #help-infra-seg.
+    platform: linux/amd64
   nsqlookupd-1:
     image: nsqio/nsq:v0.3.8
     command: >
       /nsqlookupd
       -broadcast-address localhost:4160
     ports:
-      - 4160:4160
-      - 4161:4161
+    - 4160:4160
+    - 4161:4161
 
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   nsqlookupd-2:
     image: nsqio/nsq:v0.3.8
     command: >
       /nsqlookupd
       -broadcast-address localhost:4162
     ports:
-      - 4162:4160
-      - 4163:4161
+    - 4162:4160
+    - 4163:4161
 
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   nsqlookupd-3:
     image: nsqio/nsq:v0.3.8
     command: >
       /nsqlookupd
       -broadcast-address localhost:4164
     ports:
-      - 4164:4160
-      - 4165:4161
+    - 4164:4160
+    - 4165:4161
 
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   nsqd-1:
     image: nsqio/nsq:v0.3.8
     command: >
@@ -45,13 +60,15 @@ services:
       -lookupd-tcp-address nsqlookupd-2:4160
       -lookupd-tcp-address nsqlookupd-3:4160
     ports:
-      - 4150:4150
-      - 4151:4151
+    - 4150:4150
+    - 4151:4151
     depends_on:
-      - nsqlookupd-1
-      - nsqlookupd-2
-      - nsqlookupd-3
+    - nsqlookupd-1
+    - nsqlookupd-2
+    - nsqlookupd-3
 
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   nsqd-2:
     image: nsqio/nsq:v0.3.8
     command: >
@@ -61,13 +78,15 @@ services:
       -lookupd-tcp-address nsqlookupd-2:4160
       -lookupd-tcp-address nsqlookupd-3:4160
     ports:
-      - 4152:4150
-      - 4153:4151
+    - 4152:4150
+    - 4153:4151
     depends_on:
-      - nsqlookupd-1
-      - nsqlookupd-2
-      - nsqlookupd-3
+    - nsqlookupd-1
+    - nsqlookupd-2
+    - nsqlookupd-3
 
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64
   nsqd-3:
     image: nsqio/nsq:v0.3.8
     command: >
@@ -77,9 +96,11 @@ services:
       -lookupd-tcp-address nsqlookupd-2:4160
       -lookupd-tcp-address nsqlookupd-3:4160
     ports:
-      - 4154:4150
-      - 4155:4151
+    - 4154:4150
+    - 4155:4151
     depends_on:
-      - nsqlookupd-1
-      - nsqlookupd-2
-      - nsqlookupd-3
+    - nsqlookupd-1
+    - nsqlookupd-2
+    - nsqlookupd-3
+    # See platform comment above for amd64/arm64 troubleshooting
+    platform: linux/amd64


### PR DESCRIPTION
Several Docker images used by Segment do not work reliably on Mac M1 laptops,
which use the arm64 chipset. Commonly, these are images that were built several
years ago, before M1 laptops were in widespread use, and behave unpredictably
when run on an arm64 chipset.

The simplest workaround is to ensure that the Docker environment is always
running on amd64. If this service runs on Graviton instances (which use the
arm64 chipset), then you should close this PR, or reverse the "platform" to
instead specify "linux/arm64".

This change should ensure that employees with Apple M1 laptops will be able to
reliably start and run Docker containers on this repository.

This commit may include some whitespace-only changes, which are an
artifact of the comment-preserving YAML parser that was used to modify the
docker-compose.yml file. To exclude these from the diff, append ?w=1 to the pull
request URL.

If the pull request build fails with this error:

	Unsupported config option for services.mysql: 'platform'

Replace all references to "docker-compose" in the repo with "docker compose",
which has additional functionality, and is easier to keep up to date. (This is
something that you should do anyway, even without merging this PR).

This pull request was generated by a script run by Kevin Burke. There are over
300 docker-compose files at Segment and he would appreciate your help testing
and merging this pull request. At this scale, it is not possible to satisfy
every repository's rules for formatting, labeling, and testing pull requests.

If you have questions, please post in #help-infra-seg.
JIRA: https://segment.atlassian.net/browse/IO-2101
