### PR TITLE
chore(catalog): move ownership sup-org-2329 -> sup-org-2738

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: group:default/sup-org-2329
+  owner: group:default/sup-org-2738
   system: segment-source-pipeline


### PR DESCRIPTION
Transfers Backstage catalog ownership from **sup-org-2329** (Source Pipelines) to **sup-org-2738** (Destination Pipeline).

- Updated `1` entity owner reference(s) in `catalog-info.yaml`.
- Only `owner:` lines assigned to `sup-org-2329` were changed; entities owned by other orgs (in mixed-owner files) are untouched.

Automated ownership migration.